### PR TITLE
Add example `zhimi.airp.mb5` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Since this uses [ESPHome](https://esphome.io/), adding your liberated devices to
 There are probably many more devices that could be supported, currently there are ESPHome configs for the following:
 
 [Xiaomi Smart Air Purifier 4 Lite](config/zhimi.airp.rmb1.yaml)
+[Xiaomi Smart Air Purifier 4](config/zhimi.airp.mb5.yaml)
 
 ## Building a firmware
 

--- a/components/miot/miot.cpp
+++ b/components/miot/miot.cpp
@@ -266,6 +266,8 @@ void Miot::process_message_(char *msg) {
     send_reply_(get_net_reply_());
   } else if (cmd == "time") {
     send_reply_("0"); // TODO
+  } else if (cmd == "mac") {
+    send_reply_(get_mac_address().c_str());
   } else if (cmd == "model") {
     model_ = strtok_r(nullptr, " ", &saveptr);
     if (!model_.empty())

--- a/config/zhimi.airp.mb5.yaml
+++ b/config/zhimi.airp.mb5.yaml
@@ -137,11 +137,11 @@ text_sensor:
 number:
   - platform: "miot"
     miot_siid: 9
-    miot_piid: 5
-    name: "Favorite Level"
+    miot_piid: 2
+    name: "Favorite Speed"
     icon: mdi:speedometer
     min_value: 0
-    max_value: 11
+    max_value: 2000
     step: 1
   - platform: "miot"
     miot_siid: 9
@@ -202,6 +202,19 @@ sensor:
     name: "Motor Speed"
     unit_of_measurement: "rpm"
     icon: mdi:fan
+  - platform: "miot"
+    miot_siid: 11
+    miot_piid: 1
+    name: "Total Purified Volume"
+    unit_of_measurement: "m³"
+    state_class: "measurement"
+    entity_category: diagnostic
+  - platform: "miot"
+    miot_siid: 11
+    miot_piid: 2
+    name: "Average AQI"
+    state_class: "measurement"
+    entity_category: diagnostic
 
 button:
   - platform: "miot"

--- a/config/zhimi.airp.mb5.yaml
+++ b/config/zhimi.airp.mb5.yaml
@@ -1,0 +1,212 @@
+external_components:
+  source: github://dhewg/esphome-miot@main
+
+esphome:
+  name: purifier
+  friendly_name: Air Purifier
+  comment: Xiaomi Smart Air Purifier 4 (zhimi.airp.mb5)
+  project:
+    name: "dhewg.esphome-miot"
+    version: "zhimi.airp.mb5"
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+    sdkconfig_options:
+      CONFIG_FREERTOS_UNICORE: y
+    advanced:
+      ignore_efuse_mac_crc: true
+
+logger:
+  level: DEBUG
+
+api:
+  encryption:
+    key: !secret api_encryption_key
+  reboot_timeout: 0s
+
+ota:
+  password: !secret ota_password
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    password: !secret wifi_ap_password
+
+captive_portal:
+    
+uart:
+  tx_pin: GPIO17
+  rx_pin: GPIO16
+  baud_rate: 115200
+
+miot:
+  id: miot_main
+  miot_heartbeat_siid: 11
+  miot_heartbeat_piid: 4
+
+switch:
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 1
+    name: "Power"
+    icon: mdi:power
+  - platform: "miot"
+    miot_siid: 6
+    miot_piid: 1
+    name: "Notification Sounds"
+    icon: mdi:volume-high
+    entity_category: config
+  - platform: "miot"
+    miot_siid: 8
+    miot_piid: 1
+    name: "Child Lock"
+    icon: mdi:lock
+    entity_category: config
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 6
+    name: "Ionizer"
+    icon: mdi:molecule
+    entity_category: config
+
+binary_sensor:
+  - platform: "miot"
+    miot_siid: 9
+    miot_piid: 6
+    name: "Filter Door"
+    device_class: opening
+    entity_category: diagnostic
+
+select:
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 4
+    name: "Mode"
+    options:
+      0: "Auto"
+      1: "Sleep"
+      2: "Favorite"
+      3: "Manual"
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 5
+    name: "Fan Level"
+    icon: mdi:fan
+    options:
+      1: "Low"
+      2: "Medium"
+      3: "High"
+  - platform: "miot"
+    miot_siid: 13
+    miot_piid: 2
+    name: "Display Brightness"
+    icon: mdi:brightness-6
+    entity_category: config
+    options:
+      0: "Off"
+      1: "Low"
+      2: "High"
+  - platform: "miot"
+    miot_siid: 14
+    miot_piid: 1
+    name: "Temperature Display Unit"
+    icon: mdi:temperature-celsius
+    entity_category: config
+    options:
+      1: "Celsius"
+      2: "Fahrenheit"
+
+text_sensor:
+  - platform: "miot"  
+    miot_siid: 2
+    miot_piid: 2
+    name: "Device Fault"
+    icon: mdi:fan-alert
+    entity_category: diagnostic
+    filters:
+      - substitute:
+        - "0 -> No Faults"
+        - "1 -> PM2.5 Sensor Error"
+        - "2 -> Temperature Error"
+        - "3 -> Humidity Error"
+        - "4 -> No Filter Detected"
+
+number:
+  - platform: "miot"
+    miot_siid: 9
+    miot_piid: 5
+    name: "Favorite Level"
+    icon: mdi:speedometer
+    min_value: 0
+    max_value: 11
+    step: 1
+  - platform: "miot"
+    miot_siid: 9
+    miot_piid: 4
+    name: "Manual Speed"
+    icon: mdi:speedometer
+    min_value: 0
+    max_value: 2000
+    step: 1
+
+sensor:
+  - platform: "miot"
+    miot_siid: 3
+    miot_piid: 1
+    name: "Humidity"
+    unit_of_measurement: "%"
+    device_class: humidity
+    state_class: "measurement"
+  - platform: "miot"
+    miot_siid: 3
+    miot_piid: 4
+    name: "PM2.5"
+    unit_of_measurement: "µg/m³"
+    device_class: pm25
+    state_class: "measurement"
+  - platform: "miot"
+    miot_siid: 3
+    miot_piid: 7
+    name: "Temperature"
+    unit_of_measurement: "°C"
+    device_class: temperature
+    accuracy_decimals: 1
+    state_class: "measurement"
+  - platform: "miot"
+    miot_siid: 4
+    miot_piid: 1
+    name: "Filter Life Level"
+    unit_of_measurement: "%"
+    icon: mdi:air-filter
+  - platform: "miot"
+    miot_siid: 4
+    miot_piid: 3
+    name: "Filter Use"
+    entity_category: diagnostic
+    unit_of_measurement: "h"
+    icon: mdi:air-filter
+  - platform: "miot"
+    miot_siid: 4
+    miot_piid: 4
+    name: "Filter Lifetime Remaining"
+    entity_category: diagnostic
+    unit_of_measurement: "d"
+    icon: mdi:air-filter
+  - platform: "miot"
+    miot_siid: 9
+    miot_piid: 1
+    entity_category: diagnostic
+    name: "Motor Speed"
+    unit_of_measurement: "rpm"
+    icon: mdi:fan
+
+button:
+  - platform: "miot"
+    miot_siid: 4
+    miot_aiid: 1
+    name: "Reset Filter Life"
+    icon: mdi:restart
+    entity_category: config


### PR DESCRIPTION
I flashed my `Smart Air Purifier 4 (zhimi.airp.mb5)` without any issues, just a bit of soldering required, and tested the following config to be working.

There are frequent (1/s) MCU requests for the `mac` address which isn't implemented yet, but it doesn't seem to cause any issues.
```
[W][miot:291]: Unknown command 'mac'
``` 

Example log:
```
[19:31:45][D][miot:125]: Queuing MCU command 'get_properties 2 1 2 2 2 4 2 5 2 6 3 1 3 4 3 7 4 1 4 3 4 4 6 1 8 1 9 1 9 4 9 5 9 6 13 2 14 1'
[19:31:45][V][miot:091]: Received MCU message 'get_down'
[19:31:45][V][miot:171]: Sending reply 'down get_properties 2 1 2 2 2 4 2 5 2 6 3 1 3 4 3 7 4 1 4 3 4 4 6 1 8 1 9 1 9 4 9 5 9 6 13 2 14 1' to MCU
[19:31:45][V][miot:091]: Received MCU message 'result 2 1 0 true 2 2 0 0 2 4 0 3 2 5 0 3 2 6 0 false 3 1 0 53 3 4 0 267 3 7 0 23.600000 4 1 0 100 4 3 0 2 4 4 0 291 6 1 0 false 8 1 0 false 9 1 0 1508 9 4 0 1500 9 5 0 5 9 6 0 false 13 2 0 1 14 1 0 1'
[19:31:45][V][miot.switch:012]: MCU reported switch 2:1 is: ON
[19:31:45][V][miot.text_sensor:011]: MCU reported text sensor 2:2 is: 0
[19:31:45][V][text_sensor:013]: 'Device Fault': Received new state 0
[19:31:45][D][text_sensor:064]: 'Device Fault': Sending state 'No Faults'
[19:31:45][V][miot.select:011]: MCU reported select 2:4 is: 3
[19:31:45][D][select:015]: 'Mode': Sending state Manual (index 3)
[19:31:45][V][miot.select:011]: MCU reported select 2:5 is: 3
[19:31:45][D][select:015]: 'Fan Level': Sending state High (index 2)
[19:31:45][V][miot.switch:012]: MCU reported switch 2:6 is: OFF
[19:31:45][V][miot.sensor:011]: MCU reported sensor 3:1 is: 53.000000
[19:31:45][V][sensor:043]: 'Humidity': Received new state 53.000000
[19:31:45][D][sensor:094]: 'Humidity': Sending state 53.00000 % with 0 decimals of accuracy
[19:31:45][V][miot.sensor:011]: MCU reported sensor 3:4 is: 267.000000
[19:31:45][V][sensor:043]: 'PM2.5': Received new state 267.000000
[19:31:45][D][sensor:094]: 'PM2.5': Sending state 267.00000 µg/m³ with 0 decimals of accuracy
[19:31:45][V][miot.sensor:011]: MCU reported sensor 3:7 is: 23.600000
[19:31:45][V][sensor:043]: 'Temperature': Received new state 23.600000
[19:31:45][D][sensor:094]: 'Temperature': Sending state 23.60000 °C with 1 decimals of accuracy
[19:31:45][V][miot.sensor:011]: MCU reported sensor 4:1 is: 100.000000
[19:31:45][V][sensor:043]: 'Filter Life Level': Received new state 100.000000
[19:31:45][D][sensor:094]: 'Filter Life Level': Sending state 100.00000 % with 0 decimals of accuracy
[19:31:45][V][miot.sensor:011]: MCU reported sensor 4:3 is: 2.000000
[19:31:45][V][sensor:043]: 'Filter Use': Received new state 2.000000
[19:31:45][D][sensor:094]: 'Filter Use': Sending state 2.00000 h with 0 decimals of accuracy
[19:31:45][V][miot.sensor:011]: MCU reported sensor 4:4 is: 291.000000
[19:31:45][V][sensor:043]: 'Filter Lifetime Remaining': Received new state 291.000000
[19:31:45][D][sensor:094]: 'Filter Lifetime Remaining': Sending state 291.00000 d with 0 decimals of accuracy
[19:31:45][V][miot.switch:012]: MCU reported switch 6:1 is: OFF
[19:31:45][V][miot.switch:012]: MCU reported switch 8:1 is: OFF
[19:31:45][V][miot.sensor:011]: MCU reported sensor 9:1 is: 1508.000000
[19:31:45][V][sensor:043]: 'Motor Speed': Received new state 1508.000000
[19:31:45][D][sensor:094]: 'Motor Speed': Sending state 1508.00000 rpm with 0 decimals of accuracy
[19:31:45][V][miot.number:011]: MCU reported number 9:4 is: 1500.000000
[19:31:45][D][number:012]: 'Manual Speed': Sending state 1500.000000
[19:31:45][V][miot.number:011]: MCU reported number 9:5 is: 5.000000
[19:31:45][D][number:012]: 'Favorite Level': Sending state 5.000000
[19:31:45][V][miot.binary_sensor:012]: MCU reported sensor 9:6 is: OFF
[19:31:45][V][miot.select:011]: MCU reported select 13:2 is: 1
[19:31:45][D][select:015]: 'Display Brightness': Sending state Low (index 1)
[19:31:45][V][miot.select:011]: MCU reported select 14:1 is: 1
[19:31:45][V][miot:091]: Received MCU message 'get_down'
[19:31:45][V][miot:171]: Sending reply 'down none' to MCU
[19:31:45][V][miot:091]: Received MCU message 'get_down'
[19:31:45][V][miot:171]: Sending reply 'down none' to MCU
[19:31:45][V][miot:091]: Received MCU message 'get_down'
[19:31:45][V][miot:171]: Sending reply 'down none' to MCU
[19:31:46][V][miot:091]: Received MCU message 'mac'
[19:31:46][W][miot:291]: Unknown command 'mac'
[19:31:46][V][miot:171]: Sending reply 'ok' to MCU
```

Also, do you think it makes sense to include teardown / flashing instructions in this repo also, or is that better to be left to forums and other media? -- For this device, the disassembly is extremely simple once I understood the process, but managed to break 2 clips while learning it. 