### PR TITLE
implement time command reply

### DIFF
--- a/components/miot/__init__.py
+++ b/components/miot/__init__.py
@@ -1,6 +1,6 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import uart
+from esphome.components import uart, time
 from esphome.const import CONF_ID
 
 DEPENDENCIES = ["uart"]
@@ -11,6 +11,7 @@ Miot = miot_ns.class_("Miot", cg.Component, uart.UARTDevice)
 CONF_MIOT_ID = "miot_id"
 CONF_MIOT_HEARTBEAT_SIID = "miot_heartbeat_siid"
 CONF_MIOT_HEARTBEAT_PIID = "miot_heartbeat_piid"
+CONF_MIOT_TIME = "miot_time"
 CONF_MIOT_SIID = "miot_siid"
 CONF_MIOT_PIID = "miot_piid"
 CONF_MIOT_POLL = "miot_poll"
@@ -30,6 +31,7 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(Miot),
             cv.Optional(CONF_MIOT_HEARTBEAT_SIID): cv.uint32_t,
             cv.Optional(CONF_MIOT_HEARTBEAT_PIID): cv.uint32_t,
+            cv.Optional(CONF_MIOT_TIME): cv.use_id(time.RealTimeClock),
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -43,5 +45,8 @@ async def to_code(config):
     await uart.register_uart_device(var, config)
     if (CONF_MIOT_HEARTBEAT_SIID in config) and (CONF_MIOT_HEARTBEAT_PIID in config):
         cg.add(var.set_heartbeat_config(config[CONF_MIOT_HEARTBEAT_SIID], config[CONF_MIOT_HEARTBEAT_PIID]))
+    if (CONF_MIOT_TIME in config):
+        time_ = await cg.get_variable(config[CONF_MIOT_TIME])
+        cg.add(var.set_time(time_))
 
     cg.add_define("USE_OTA_STATE_CALLBACK")

--- a/components/miot/__init__.py
+++ b/components/miot/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import uart, time
-from esphome.const import CONF_ID
+from esphome.const import CONF_ID, CONF_TIME_ID
 
 DEPENDENCIES = ["uart"]
 
@@ -11,7 +11,6 @@ Miot = miot_ns.class_("Miot", cg.Component, uart.UARTDevice)
 CONF_MIOT_ID = "miot_id"
 CONF_MIOT_HEARTBEAT_SIID = "miot_heartbeat_siid"
 CONF_MIOT_HEARTBEAT_PIID = "miot_heartbeat_piid"
-CONF_MIOT_TIME = "miot_time"
 CONF_MIOT_SIID = "miot_siid"
 CONF_MIOT_PIID = "miot_piid"
 CONF_MIOT_POLL = "miot_poll"
@@ -31,7 +30,7 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(Miot),
             cv.Optional(CONF_MIOT_HEARTBEAT_SIID): cv.uint32_t,
             cv.Optional(CONF_MIOT_HEARTBEAT_PIID): cv.uint32_t,
-            cv.Optional(CONF_MIOT_TIME): cv.use_id(time.RealTimeClock),
+            cv.Optional(cv.GenerateID(CONF_TIME_ID)): cv.use_id(time.RealTimeClock),
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -45,8 +44,8 @@ async def to_code(config):
     await uart.register_uart_device(var, config)
     if (CONF_MIOT_HEARTBEAT_SIID in config) and (CONF_MIOT_HEARTBEAT_PIID in config):
         cg.add(var.set_heartbeat_config(config[CONF_MIOT_HEARTBEAT_SIID], config[CONF_MIOT_HEARTBEAT_PIID]))
-    if (CONF_MIOT_TIME in config):
-        time_ = await cg.get_variable(config[CONF_MIOT_TIME])
+    if (CONF_TIME_ID in config):
+        time_ = await cg.get_variable(config[CONF_TIME_ID])
         cg.add(var.set_time(time_))
 
     cg.add_define("USE_OTA_STATE_CALLBACK")

--- a/components/miot/__init__.py
+++ b/components/miot/__init__.py
@@ -1,7 +1,7 @@
 import esphome.codegen as cg
 import esphome.config_validation as cv
-from esphome.components import uart, time
-from esphome.const import CONF_ID, CONF_TIME_ID
+from esphome.components import uart
+from esphome.const import CONF_ID
 
 DEPENDENCIES = ["uart"]
 
@@ -30,7 +30,6 @@ CONFIG_SCHEMA = cv.All(
             cv.GenerateID(): cv.declare_id(Miot),
             cv.Optional(CONF_MIOT_HEARTBEAT_SIID): cv.uint32_t,
             cv.Optional(CONF_MIOT_HEARTBEAT_PIID): cv.uint32_t,
-            cv.Optional(cv.GenerateID(CONF_TIME_ID)): cv.use_id(time.RealTimeClock),
         }
     )
     .extend(cv.COMPONENT_SCHEMA)
@@ -44,8 +43,5 @@ async def to_code(config):
     await uart.register_uart_device(var, config)
     if (CONF_MIOT_HEARTBEAT_SIID in config) and (CONF_MIOT_HEARTBEAT_PIID in config):
         cg.add(var.set_heartbeat_config(config[CONF_MIOT_HEARTBEAT_SIID], config[CONF_MIOT_HEARTBEAT_PIID]))
-    if (CONF_TIME_ID in config):
-        time_ = await cg.get_variable(config[CONF_TIME_ID])
-        cg.add(var.set_time(time_))
 
     cg.add_define("USE_OTA_STATE_CALLBACK")

--- a/components/miot/miot.cpp
+++ b/components/miot/miot.cpp
@@ -119,7 +119,7 @@ void Miot::dump_config() {
 #ifdef USE_TIME
     ESP_LOGCONFIG(TAG, "  Time: %s", YESNO(time_ != nullptr));
 #else 
-    ESP_LOGCONFIG(TAG, "  Time: UNAVAILABLE";
+    ESP_LOGCONFIG(TAG, "  Time: UNAVAILABLE");
 #endif
 }
 

--- a/components/miot/miot.cpp
+++ b/components/miot/miot.cpp
@@ -276,11 +276,6 @@ const char *Miot::get_net_reply_() {
 
 std::string Miot::get_time_reply_(char **saveptr) {
 #ifdef USE_TIME
-  if (this->time_ == nullptr) {
-    ESP_LOGW(TAG, "MCU time request: time source available but not configured");
-    return "0";
-  }
-
   if (!time_->now().is_valid()) {
     ESP_LOGW(TAG, "MCU time request: time source not ready yet");
     return "0";

--- a/components/miot/miot.cpp
+++ b/components/miot/miot.cpp
@@ -117,7 +117,7 @@ void Miot::dump_config() {
   if (!mcu_version_.empty())
     ESP_LOGCONFIG(TAG, "  MCU Version: %s", mcu_version_.c_str());
 #ifdef USE_TIME
-    ESP_LOGCONFIG(TAG, "  Time: %s", YESNO(time_ != nullptr));
+    ESP_LOGCONFIG(TAG, "  Time: AVAILABLE");
 #else 
     ESP_LOGCONFIG(TAG, "  Time: UNAVAILABLE");
 #endif

--- a/components/miot/miot.h
+++ b/components/miot/miot.h
@@ -7,10 +7,6 @@
 
 #include "esphome/core/component.h"
 #include "esphome/components/uart/uart.h"
-#ifdef USE_TIME
-#include "esphome/components/time/real_time_clock.h"
-#include "esphome/core/time.h"
-#endif
 
 namespace esphome {
 namespace miot {
@@ -61,11 +57,6 @@ class Miot : public Component, public uart::UARTDevice {
     this->heartbeat_siid_ = siid;
     this->heartbeat_piid_ = piid;
   };
-#ifdef USE_TIME
-  void set_time(time::RealTimeClock *time) { 
-    this->time_ = time; 
-  };
-#endif
   void register_listener(uint32_t siid, uint32_t piid, bool poll, MiotValueType type, const std::function<void(const MiotValue &value)> &func);
   void queue_command(const std::string &cmd);
   void queue_command(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
@@ -93,9 +84,6 @@ class Miot : public Component, public uart::UARTDevice {
   bool expect_action_result_{false};
   uint32_t heartbeat_siid_{0};
   uint32_t heartbeat_piid_{0};
-#ifdef USE_TIME
-  time::RealTimeClock *time_{nullptr};
-#endif
   std::map<std::pair<uint32_t, uint32_t>, MiotListener> listeners_;
 };
 

--- a/components/miot/miot.h
+++ b/components/miot/miot.h
@@ -75,7 +75,7 @@ class Miot : public Component, public uart::UARTDevice {
 
  protected:
   const char *get_net_reply_();
-  std::string get_time_reply_(char **saveptr);
+  std::string get_time_reply_(bool posix);
   void send_reply_(const char *reply);
   void update_property(uint32_t siid, uint32_t piid, const char *value);
   void update_properties(char **saveptr, MiotResultFormat format);

--- a/components/miot/miot.h
+++ b/components/miot/miot.h
@@ -7,6 +7,10 @@
 
 #include "esphome/core/component.h"
 #include "esphome/components/uart/uart.h"
+#ifdef USE_TIME
+#include "esphome/components/time/real_time_clock.h"
+#include "esphome/core/time.h"
+#endif
 
 namespace esphome {
 namespace miot {
@@ -57,6 +61,11 @@ class Miot : public Component, public uart::UARTDevice {
     this->heartbeat_siid_ = siid;
     this->heartbeat_piid_ = piid;
   };
+#ifdef USE_TIME
+  void set_time(time::RealTimeClock *time) { 
+    this->time_ = time; 
+  };
+#endif
   void register_listener(uint32_t siid, uint32_t piid, bool poll, MiotValueType type, const std::function<void(const MiotValue &value)> &func);
   void queue_command(const std::string &cmd);
   void queue_command(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
@@ -66,6 +75,7 @@ class Miot : public Component, public uart::UARTDevice {
 
  protected:
   const char *get_net_reply_();
+  std::string get_time_reply_(char **saveptr);
   void send_reply_(const char *reply);
   void update_property(uint32_t siid, uint32_t piid, const char *value);
   void update_properties(char **saveptr, MiotResultFormat format);
@@ -83,6 +93,9 @@ class Miot : public Component, public uart::UARTDevice {
   bool expect_action_result_{false};
   uint32_t heartbeat_siid_{0};
   uint32_t heartbeat_piid_{0};
+#ifdef USE_TIME
+  time::RealTimeClock *time_{nullptr};
+#endif
   std::map<std::pair<uint32_t, uint32_t>, MiotListener> listeners_;
 };
 


### PR DESCRIPTION
This PR adds support for the `time` MCU command, in both `posix` and local time formats.

The `posix` response is the UTC timestamp, and the simple command is in the local time, as defined by the timezone in the configuration.

I tried to make it work without the `miot_time` configuration variable, but I couldn't find a way to get a reference to the time otherwise, in the style of your `ota::global_ota_component->add_on_state_callback`. Hints appreciated.

Example YAML config:
```yaml
time:
  - platform: homeassistant
    id: homeassistant_time
    timezone: "Europe/Bucharest"

miot:
  id: miot_main
  miot_time: homeassistant_time
```
Example verbose log:
```
[16:55:08][V][miot:091]: Received MCU message 'time posix'
[16:55:08][D][miot:294]: MCU time request: sending posix time "1708174508"
[16:55:08][V][miot:183]: Sending reply '1708174508' to MCU
```
Although my MCU doesn't send the non-posix `time` command, I assume it will work per the blakadder specs. Here's an on-device log of how that looks:
```
[17:04:26][D][miot:332]: MCU time request: sending time "2024-02-17 17:04:25"
```

Disclaimer: I'm not a C++ guy, so any style/syntax/code nasties or other foot-guns you spot, I can change. :) 

Hopefully the code is in good enough shape to merge, but I've had fun nonetheless implementing this.