### PR TITLE
Add example `mmgg.feeder.fi1` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Xiaomi Smart Air Purifier 4 | zhimi.airp.mb5 | [link](../../wiki/Xiaomi-Smart-Ai
 Xiaomi Smart Air Purifier 4 Lite | zhimi.airp.rmb1 | [link](../../wiki/Xiaomi-Smart-Air-Purifier-4-Lite-(zhimi.airp.rmb1)) | [zhimi.airp.rmb1](config/zhimi.airp.rmb1.yaml) | [link](https://home.miot-spec.com/spec/zhimi.airp.rmb1)
 Xiaomi Smart Air Purifier 4 Pro | zhimi.airp.vb4 |  | [zhimi.airp.vb4](config/zhimi.airp.vb4.yaml) | [link](https://home.miot-spec.com/spec?type=urn:miot-spec-v2:device:air-purifier:0000A007:zhimi-vb4:1)
 Xiaomi Mi Smart Standing Fan 2 | dmaker.fan.p18 |  | [dmaker.fan.p18](config/dmaker.fan.p18.yaml) | [link](https://home.miot-spec.com/spec/dmaker.fan.p18)
+Xiaomi Smart Pet Food Feeder | mmgg.feeder.fi1 | [link](../../wiki/Xiaomi-Smart-Pet-Food-Feeder) | [mmgg.feeder.fi1](config/mmgg.feeder.fi1.yaml) | [link](https://home.miot-spec.com/spec/mmgg.feeder.fi1)
 
 Some of the devices have more than one model (like Mi Air Purifier 3C). If their MIoT specifications are compatible, the ESPHome config will be usable with all of them.
 

--- a/config/mmgg.feeder.fi1.yaml
+++ b/config/mmgg.feeder.fi1.yaml
@@ -31,27 +31,24 @@ api:
   on_client_connected:
     then:
       # Refresh the feed plan when HA connects
-      - lambda: 'id(miot_main).queue_command("action 5 6 11 0");'
+      - lambda: id(miot_main).queue_command("action 5 6 11 0");
   services:
     # DEBUG ONLY: Send **arbitrary commands** to MCU from HA
     - service: mcu_command
       variables:
         command: string
       then:
-        - lambda: 'id(miot_main).queue_command(command);'
+        - lambda: id(miot_main).queue_command(command);
     # Refresh the "Raw Feed Plan" sensor on demand
     - service: get_feed_plan
       then:
-        - lambda: 'id(miot_main).queue_command("action 5 6 11 0");'
+        - lambda: id(miot_main).queue_command("action 5 6 11 0");
     # Dispense the specified amount of portions
     - service: dispense_food
       variables:
         portions: int
       then:
-        - lambda: |
-            char cmd[512];
-            snprintf(cmd, sizeof(cmd), "action 2 1 5 %i", portions);
-            id(miot_main).queue_command(cmd);
+        - lambda: id(miot_main).queue_command("action 2 1 5 %i", portions);
     # Add a new scheduled feeding time to MCU memory
     - service: add_scheduled_feed
       variables:
@@ -61,12 +58,11 @@ api:
         portions: int
       then:
         - lambda: |
-            char cmd[512];
-            snprintf(cmd, sizeof(cmd), "action 5 7 10 %i 6 %i 7 %i 8 %i",
-                     id, hour, minute, portions);
-            id(miot_main).queue_command(cmd);
-            // Manually refresh the feed plan afterwards
-            id(miot_main).queue_command("action 5 6 11 0");
+            id(miot_main).queue_command(
+              "action 5 7 10 %i 6 %i 7 %i 8 %i",
+              id, hour, minute, portions);
+        # Manually refresh the feed plan afterwards
+        - lambda: id(miot_main).queue_command("action 5 6 11 0");
     # Edit a scheduled feeding time in MCU memory
     - service: edit_scheduled_feed
       variables:
@@ -76,23 +72,19 @@ api:
         portions: int
       then:
         - lambda: |
-            char cmd[512];
-            snprintf(cmd, sizeof(cmd), "action 5 8 10 %i 6 %i 7 %i 8 %i",
-                     id, hour, minute, portions);
-            id(miot_main).queue_command(cmd);
-            // Manually refresh the feed plan afterwards
-            id(miot_main).queue_command("action 5 6 11 0");
+            id(miot_main).queue_command(
+              "action 5 8 10 %i 6 %i 7 %i 8 %i",
+              id, hour, minute, portions);
+        # Manually refresh the feed plan afterwards
+        - lambda: id(miot_main).queue_command("action 5 6 11 0");
     # Remove a scheduled feeding time from MCU memory
     - service: remove_scheduled_feed
       variables:
         id: int
       then:
-        - lambda: |
-            char cmd[512];
-            snprintf(cmd, sizeof(cmd), "action 5 9 10 %i", id);
-            id(miot_main).queue_command(cmd);
-            // Manually refresh the feed plan afterwards
-            id(miot_main).queue_command("action 5 6 11 0");
+        - lambda: id(miot_main).queue_command("action 5 9 10 %i", id);
+        # Manually refresh the feed plan afterwards
+        - lambda: id(miot_main).queue_command("action 5 6 11 0");
 
 ota:
   password: !secret feeder_ota_password

--- a/config/mmgg.feeder.fi1.yaml
+++ b/config/mmgg.feeder.fi1.yaml
@@ -31,7 +31,7 @@ api:
   on_client_connected:
     then:
       # Refresh the feed plan when HA connects
-      - lambda: id(miot_main).queue_command("action 5 6 11 0");
+      - lambda: id(miot_main).execute_action(5, 6, "11 0");
   services:
     # DEBUG ONLY: Send **arbitrary commands** to MCU from HA
     - service: mcu_command
@@ -42,7 +42,7 @@ api:
     # Refresh the "Raw Feed Plan" sensor on demand
     - service: get_feed_plan
       then:
-        - lambda: id(miot_main).queue_command("action 5 6 11 0");
+        - lambda: id(miot_main).execute_action(5, 6, "11 0");
     # Dispense the specified amount of portions
     - service: dispense_food
       variables:
@@ -62,7 +62,7 @@ api:
               "action 5 7 10 %i 6 %i 7 %i 8 %i",
               id, hour, minute, portions);
         # Manually refresh the feed plan afterwards
-        - lambda: id(miot_main).queue_command("action 5 6 11 0");
+        - lambda: id(miot_main).execute_action(5, 6, "11 0");
     # Edit a scheduled feeding time in MCU memory
     - service: edit_scheduled_feed
       variables:
@@ -76,7 +76,7 @@ api:
               "action 5 8 10 %i 6 %i 7 %i 8 %i",
               id, hour, minute, portions);
         # Manually refresh the feed plan afterwards
-        - lambda: id(miot_main).queue_command("action 5 6 11 0");
+        - lambda: id(miot_main).execute_action(5, 6, "11 0");
     # Remove a scheduled feeding time from MCU memory
     - service: remove_scheduled_feed
       variables:
@@ -84,7 +84,7 @@ api:
       then:
         - lambda: id(miot_main).queue_command("action 5 9 10 %i", id);
         # Manually refresh the feed plan afterwards
-        - lambda: id(miot_main).queue_command("action 5 6 11 0");
+        - lambda: id(miot_main).execute_action(5, 6, "11 0");
 
 ota:
   password: !secret feeder_ota_password

--- a/config/mmgg.feeder.fi1.yaml
+++ b/config/mmgg.feeder.fi1.yaml
@@ -371,3 +371,9 @@ event:
           event_type: "start"
       # Update "Dispensing" status on the UI
       - script.execute: refresh_feed_plan
+  - platform: "miot"
+    miot_siid: 9
+    miot_eiid: 1
+    id: power_loss
+    name: "Power Loss"
+    event_type: power_loss

--- a/config/mmgg.feeder.fi1.yaml
+++ b/config/mmgg.feeder.fi1.yaml
@@ -40,7 +40,7 @@ api:
       then:
         - lambda: id(miot_main).queue_command(command);
     # Refresh the "Raw Feed Plan" sensor on demand
-    - service: get_feed_plan
+    - service: refresh_feed_plan
       then:
         - lambda: id(miot_main).execute_action(5, 6, "11 0");
     # Dispense the specified amount of portions
@@ -175,11 +175,22 @@ text_sensor:
   - platform: "miot"
     miot_siid: 4
     miot_piid: 5
-    name: "Last Feed Source ID"
+    name: "Last Feed Source"
     icon: mdi:food-apple
+    miot_poll: false
     filters:
       - map:
-        - "255 -> Manual"
+        - "0 -> Schedule 0"
+        - "1 -> Schedule 1"
+        - "2 -> Schedule 2"
+        - "3 -> Schedule 3"
+        - "4 -> Schedule 4"
+        - "5 -> Schedule 5"
+        - "6 -> Schedule 6"
+        - "7 -> Schedule 7"
+        - "8 -> Schedule 8"
+        - "9 -> Schedule 9"
+        - "255 -> Manual Feed"
   # FeedID,Hour,Minute,Portions,(Dispensed=0,Pending=255) x5
   - platform: "miot"
     miot_siid: 5
@@ -215,6 +226,7 @@ sensor:
     miot_piid: 4
     name: "Last Feed Portions"
     icon: mdi:food-apple
+    miot_poll: false
   - platform: "miot"
     miot_siid: 8
     miot_piid: 1

--- a/config/mmgg.feeder.fi1.yaml
+++ b/config/mmgg.feeder.fi1.yaml
@@ -270,9 +270,6 @@ sensor:
     name: "Last Feed Portions"
     icon: mdi:food-apple
     miot_poll: false
-    on_value:
-      then:
-        - execute-script: refresh_feed_plan
   - platform: "miot"
     miot_siid: 8
     miot_piid: 1
@@ -309,3 +306,45 @@ button:
     miot_aiid: 1
     name: "Reset Dessicant Timer"
     icon: mdi:restart
+
+event:
+  # Combined feed event
+  - platform: "template"
+    name: 'Feed Event'
+    id: feed_event
+    event_types:
+      - 'start'
+      - 'stats'
+      - 'success'
+  - platform: "miot"
+    miot_siid: 4
+    miot_eiid: 1
+    event_type: feedsuccess
+    internal: true
+    on_event:
+      - event.trigger:
+          id: feed_event
+          event_type: "success"
+      # Update "Dispensed" status on the UI
+      - delay: 500ms
+      - execute-script: refresh_feed_plan
+  - platform: "miot"
+    miot_siid: 4
+    miot_eiid: 2
+    event_type: feedstats
+    internal: true
+    on_event:
+      - event.trigger:
+          id: feed_event
+          event_type: "stats"
+  - platform: "miot"
+    miot_siid: 4
+    miot_eiid: 3
+    event_type: feedstart
+    internal: true
+    on_event:
+      - event.trigger:
+          id: feed_event
+          event_type: "start"
+      # Update "Dispensing" status on the UI
+      - execute-script: refresh_feed_plan

--- a/config/mmgg.feeder.fi1.yaml
+++ b/config/mmgg.feeder.fi1.yaml
@@ -200,7 +200,6 @@ text_sensor:
   - platform: "miot"
     miot_siid: 4
     miot_piid: 5
-    id: outfood_num
     name: "Last Feed Source"
     icon: mdi:food-apple
     miot_poll: false
@@ -278,6 +277,7 @@ sensor:
     miot_siid: 4
     miot_piid: 4
     name: "Last Feed Portions"
+    id: outfood_num
     icon: mdi:food-apple
     miot_poll: false
   - platform: "miot"
@@ -331,6 +331,7 @@ event:
       - 'start'
       - 'stats'
       - 'success'
+    icon: mdi:food-apple
   - platform: "miot"
     miot_siid: 4
     miot_eiid: 1
@@ -377,3 +378,4 @@ event:
     id: power_loss
     name: "Power Loss"
     event_type: power_loss
+    icon: mdi:power-plug-off

--- a/config/mmgg.feeder.fi1.yaml
+++ b/config/mmgg.feeder.fi1.yaml
@@ -11,6 +11,12 @@ substitutions:
   # "Dispense Food" button portions (1 ~ 30).
   dispense_food_portions: "1"
 
+scripts:
+  - id: refresh_feed_plan
+    then:
+      - lambda: id(miot_main).execute_action(5, 6, "11 0");
+      - lambda: id(miot_main).execute_action(5, 6, "11 1");
+
 esphome:
   name: feeder
   friendly_name: Pet Feeder
@@ -27,8 +33,7 @@ time:
       cron: "0 1 0 * * *"
       then: 
         # Refresh the feed plan status at midnight + 1min buffer
-        - lambda: id(miot_main).execute_action(5, 6, "11 0");
-        - lambda: id(miot_main).execute_action(5, 6, "11 1");
+        - execute-script: refresh_feed_plan
 
 esp8266:
   board: esp_wroom_02
@@ -45,8 +50,7 @@ api:
   on_client_connected:
     then:
       # Refresh the feed plan when HA connects
-      - lambda: id(miot_main).execute_action(5, 6, "11 0");
-      - lambda: id(miot_main).execute_action(5, 6, "11 1");
+      - execute-script: refresh_feed_plan
   services:
     # DEBUG ONLY: Send **arbitrary commands** to MCU from HA
     - service: mcu_command
@@ -57,8 +61,7 @@ api:
     # Refresh the "Raw Feed Plan" sensor on demand
     - service: refresh_feed_plan
       then:
-        - lambda: id(miot_main).execute_action(5, 6, "11 0");
-        - lambda: id(miot_main).execute_action(5, 6, "11 1");
+        - execute-script: refresh_feed_plan
     # Dispense the specified amount of portions
     - service: dispense_food
       variables:
@@ -77,9 +80,7 @@ api:
             id(miot_main).queue_command(
               "action 5 7 10 %i 6 %i 7 %i 8 %i",
               id, hour, minute, portions);
-        # Manually refresh the feed plan afterwards
-        - lambda: id(miot_main).execute_action(5, 6, "11 0");
-        - lambda: id(miot_main).execute_action(5, 6, "11 1");
+        - execute-script: refresh_feed_plan
     # Edit a scheduled feeding time in MCU memory
     - service: edit_scheduled_feed
       variables:
@@ -92,18 +93,14 @@ api:
             id(miot_main).queue_command(
               "action 5 8 10 %i 6 %i 7 %i 8 %i",
               id, hour, minute, portions);
-        # Manually refresh the feed plan afterwards
-        - lambda: id(miot_main).execute_action(5, 6, "11 0");
-        - lambda: id(miot_main).execute_action(5, 6, "11 1");
+        - execute-script: refresh_feed_plan
     # Remove a scheduled feeding time from MCU memory
     - service: remove_scheduled_feed
       variables:
         id: int
       then:
         - lambda: id(miot_main).queue_command("action 5 9 10 %i", id);
-        # Manually refresh the feed plan afterwards
-        - lambda: id(miot_main).execute_action(5, 6, "11 0");
-        - lambda: id(miot_main).execute_action(5, 6, "11 1");
+        - execute-script: refresh_feed_plan
 
 ota:
   password: !secret feeder_ota_password
@@ -275,9 +272,7 @@ sensor:
     miot_poll: false
     on_value:
       then:
-        # Refresh feed plan status after feed event
-        - lambda: id(miot_main).execute_action(5, 6, "11 0");
-        - lambda: id(miot_main).execute_action(5, 6, "11 1");
+        - execute-script: refresh_feed_plan
   - platform: "miot"
     miot_siid: 8
     miot_piid: 1

--- a/config/mmgg.feeder.fi1.yaml
+++ b/config/mmgg.feeder.fi1.yaml
@@ -237,7 +237,7 @@ text_sensor:
         feeding_schedule.pop_back(); // Remove the trailing comma
       }
       return feeding_schedule;
-  # FeedID,Hour,Minute,Portions,(Dispensed=0,Pending=255,Dispensing=254) x5
+  # FeedID,Hour,Minute,Portions,(Dispensed=0,Failed=1,Dispensing=254,Pending=255) x5
   - platform: "miot"
     id: feedplan_string
     miot_siid: 5
@@ -274,9 +274,11 @@ number:
     step: 1
     min_value: -12
     max_value: 12
+    mode: box
+    unit_of_measurement: hours
   - platform: template
     id: dispense_food_portions
-    name: "Dispense portions"
+    name: "Dispense Amount"
     icon: mdi:food-apple
     min_value: 1
     max_value: 30
@@ -285,15 +287,18 @@ number:
     restore_value: False
     initial_value: 1
     entity_category: config
+    unit_of_measurement: portions
+    mode: box
 
 sensor:
   - platform: "miot"
     miot_siid: 4
     miot_piid: 4
-    name: "Last Feed Portions"
+    name: "Last Feed Amount"
     id: outfood_num
     icon: mdi:food-apple
     miot_poll: false
+    unit_of_measurement: portions
   - platform: "miot"
     miot_siid: 8
     miot_piid: 1
@@ -313,9 +318,11 @@ sensor:
     icon: mdi:clock
     entity_category: diagnostic
   - platform: "template"
-    name: "Portions Dispensed Today"
-    id: portions_dispensed_today_sensor
+    name: "Dispensed Today"
+    id: dispensed_today
     accuracy_decimals: 0
+    icon: mdi:food-apple
+    unit_of_measurement: portions
     lambda: return id(portions_dispensed_today);
 
 button:
@@ -361,7 +368,7 @@ event:
           id: portions_dispensed_today
           value: !lambda return id(portions_dispensed_today) + id(outfood_num).state;
       - component.update:
-          id: portions_dispensed_today_sensor
+          id: dispensed_today
       # Update "Dispensed" status on the UI
       - delay: 500ms
       - script.execute: refresh_feed_plan

--- a/config/mmgg.feeder.fi1.yaml
+++ b/config/mmgg.feeder.fi1.yaml
@@ -1,8 +1,11 @@
 # https://home.miot-spec.com/spec/mmgg.feeder.fi1
-# TODO: Currently only supports displaying 5 programmed feed plans instead of the full 10
-# TODO: Currently only supports displaying programmed feed plans in raw form
+# TODO: Automatically adjust "phon-timezone" based on home assistant time for DST.
 external_components:
   source: github://dhewg/esphome-miot@main
+
+globals:
+  - id: schedule
+    type: std::map<std::string, std::string>
 
 substitutions:
   # "Dispense Food" button portions (1 ~ 30).
@@ -20,12 +23,18 @@ time:
   - platform: homeassistant
     id: homeassistant_time
     timezone: GMT0
+    on_time: 
+      cron: "0 1 0 * * *"
+      then: 
+        # Refresh the feed plan status at midnight + 1min buffer
+        - lambda: id(miot_main).execute_action(5, 6, "11 0");
+        - lambda: id(miot_main).execute_action(5, 6, "11 1");
 
 esp8266:
   board: esp_wroom_02
 
 logger:
-  level: VERBOSE
+  level: DEBUG
   # Important: Disable UART1 logging to avoid hardware errors on main UART0
   baud_rate: 0
 
@@ -37,6 +46,7 @@ api:
     then:
       # Refresh the feed plan when HA connects
       - lambda: id(miot_main).execute_action(5, 6, "11 0");
+      - lambda: id(miot_main).execute_action(5, 6, "11 1");
   services:
     # DEBUG ONLY: Send **arbitrary commands** to MCU from HA
     - service: mcu_command
@@ -48,6 +58,7 @@ api:
     - service: refresh_feed_plan
       then:
         - lambda: id(miot_main).execute_action(5, 6, "11 0");
+        - lambda: id(miot_main).execute_action(5, 6, "11 1");
     # Dispense the specified amount of portions
     - service: dispense_food
       variables:
@@ -68,6 +79,7 @@ api:
               id, hour, minute, portions);
         # Manually refresh the feed plan afterwards
         - lambda: id(miot_main).execute_action(5, 6, "11 0");
+        - lambda: id(miot_main).execute_action(5, 6, "11 1");
     # Edit a scheduled feeding time in MCU memory
     - service: edit_scheduled_feed
       variables:
@@ -82,6 +94,7 @@ api:
               id, hour, minute, portions);
         # Manually refresh the feed plan afterwards
         - lambda: id(miot_main).execute_action(5, 6, "11 0");
+        - lambda: id(miot_main).execute_action(5, 6, "11 1");
     # Remove a scheduled feeding time from MCU memory
     - service: remove_scheduled_feed
       variables:
@@ -90,6 +103,7 @@ api:
         - lambda: id(miot_main).queue_command("action 5 9 10 %i", id);
         # Manually refresh the feed plan afterwards
         - lambda: id(miot_main).execute_action(5, 6, "11 0");
+        - lambda: id(miot_main).execute_action(5, 6, "11 1");
 
 ota:
   password: !secret feeder_ota_password
@@ -196,20 +210,56 @@ text_sensor:
         - "8 -> Schedule 8"
         - "9 -> Schedule 9"
         - "255 -> Manual Feed"
-  # FeedID,Hour,Minute,Portions,(Dispensed=0,Pending=255) x5
+  - platform: template
+    name: "Raw Feed Plan"
+    id: raw_feed_plan
+    icon: mdi:calendar-clock
+    polling_interval: never
+    entity_category: diagnostic
+    lambda: |-
+      std::string feeding_schedule;
+      for (auto &entry : id(schedule)) {
+        if (entry.second.find("255") == 0) {
+          continue; // Skip empty entries
+        }
+        feeding_schedule += entry.first + "," + entry.second + ",";
+      }
+      if (!feeding_schedule.empty()) {
+        feeding_schedule.pop_back(); // Remove the trailing comma
+      }
+      return feeding_schedule;
+  # FeedID,Hour,Minute,Portions,(Dispensed=0,Pending=255,Dispensing=254) x5
   - platform: "miot"
+    id: feedplan_string
     miot_siid: 5
     miot_piid: 12
     miot_poll: false
-    name: "Raw Feed Plan"
-    entity_category: diagnostic
-    icon: mdi:calendar
+    internal: true
+    on_value:
+      - lambda: |-
+          char* token = strtok(x.data(), ",");
+          while (token != NULL) {
+            std::string feed_id = std::string(token);
+            token = strtok(NULL, ",");
+            std::string hour = std::string(token);
+            token = strtok(NULL, ",");
+            std::string minute = std::string(token);
+            token = strtok(NULL, ",");
+            std::string portions = std::string(token);
+            token = strtok(NULL, ",");
+            std::string status = std::string(token);
+            token = strtok(NULL, ",");
+          
+            std::string details = hour + "," + minute + "," + portions + "," + status;
+            id(schedule)[feed_id] = details;
+          }
+      - lambda: id(raw_feed_plan).update();
 
 number:
   - platform: "miot"    
     miot_siid: 9
     miot_piid: 12
-    name: "Phone Timezone"
+    name: "Timezone Offset"
     icon: mdi:clock
     entity_category: config
     step: 1
@@ -223,6 +273,11 @@ sensor:
     name: "Last Feed Portions"
     icon: mdi:food-apple
     miot_poll: false
+    on_value:
+      then:
+        # Refresh feed plan status after feed event
+        - lambda: id(miot_main).execute_action(5, 6, "11 0");
+        - lambda: id(miot_main).execute_action(5, 6, "11 1");
   - platform: "miot"
     miot_siid: 8
     miot_piid: 1

--- a/config/mmgg.feeder.fi1.yaml
+++ b/config/mmgg.feeder.fi1.yaml
@@ -6,6 +6,10 @@ external_components:
 globals:
   - id: schedule
     type: std::map<std::string, std::string>
+  - id: portions_dispensed_today
+    type: int
+    restore_value: True
+    initial_value: "0"
 
 substitutions:
   # "Dispense Food" button portions (1 ~ 30).
@@ -30,10 +34,15 @@ time:
     id: homeassistant_time
     timezone: GMT0
     on_time: 
-      cron: "0 1 0 * * *"
-      then: 
-        # Refresh the feed plan status at midnight + 1min buffer
-        - execute-script: refresh_feed_plan
+      # Every day at 00:01:00
+      - hours: 0
+        minutes: 1 # buffer to make sure MCU schedule has been refreshed
+        seconds: 0
+        then:
+          - execute-script: refresh_feed_plan
+          - globals.set: 
+              id: portions_dispensed_today
+              value: "0"
 
 esp8266:
   board: esp_wroom_02
@@ -191,6 +200,7 @@ text_sensor:
   - platform: "miot"
     miot_siid: 4
     miot_piid: 5
+    id: outfood_num
     name: "Last Feed Source"
     icon: mdi:food-apple
     miot_poll: false
@@ -288,6 +298,11 @@ sensor:
     name: "Device Country"
     icon: mdi:clock
     entity_category: diagnostic
+  - platform: "template"
+    name: "Portions Dispensed Today"
+    id: portions_dispensed_today_sensor
+    accuracy_decimals: 0
+    lambda: return id(portions_dispensed_today);
 
 button:
   - platform: "miot"
@@ -325,6 +340,11 @@ event:
       - event.trigger:
           id: feed_event
           event_type: "success"
+      - globals.set: 
+          id: portions_dispensed_today
+          value: !lambda return id(portions_dispensed_today) + id(outfood_num).state;
+      - component.update:
+          id: portions_dispensed_today_sensor
       # Update "Dispensed" status on the UI
       - delay: 500ms
       - execute-script: refresh_feed_plan

--- a/config/mmgg.feeder.fi1.yaml
+++ b/config/mmgg.feeder.fi1.yaml
@@ -1,0 +1,255 @@
+# https://home.miot-spec.com/spec/mmgg.feeder.fi1
+# TODO: Currently only supports displaying 5 programmed feed plans instead of the full 10
+# TODO: Currently only supports displaying programmed feed plans in raw form
+external_components:
+  source: github://dhewg/esphome-miot@main
+
+substitutions:
+  # "Dispense Food" button portions (1 ~ 30).
+  dispense_food_portions: "1"
+
+esphome:
+  name: feeder
+  friendly_name: Pet Feeder
+  comment: Xiaomi Smart Pet Food Feeder (mmgg.feeder.fi1)
+  project:
+    name: "dhewg.esphome-miot"
+    version: "mmgg.feeder.fi1"
+
+esp8266:
+  board: esp_wroom_02
+
+logger:
+  level: VERBOSE
+  # Important: Disable UART1 logging to avoid hardware errors on main UART0
+  baud_rate: 0
+
+api:
+  encryption:
+    key: !secret feeder_api_key
+  reboot_timeout: 0s
+  on_client_connected:
+    then:
+      # Refresh the feed plan when HA connects
+      - lambda: 'id(miot_main).queue_command("action 5 6 11 0");'
+  services:
+    # DEBUG ONLY: Send **arbitrary commands** to MCU from HA
+    - service: mcu_command
+      variables:
+        command: string
+      then:
+        - lambda: 'id(miot_main).queue_command(command);'
+    # Refresh the "Raw Feed Plan" sensor on demand
+    - service: get_feed_plan
+      then:
+        - lambda: 'id(miot_main).queue_command("action 5 6 11 0");'
+    # Dispense the specified amount of portions
+    - service: dispense_food
+      variables:
+        portions: int
+      then:
+        - lambda: |
+            char cmd[512];
+            snprintf(cmd, sizeof(cmd), "action 2 1 5 %i", portions);
+            id(miot_main).queue_command(cmd);
+    # Add a new scheduled feeding time to MCU memory
+    - service: add_scheduled_feed
+      variables:
+        id: int
+        hour: int
+        minute: int
+        portions: int
+      then:
+        - lambda: |
+            char cmd[512];
+            snprintf(cmd, sizeof(cmd), "action 5 7 10 %i 6 %i 7 %i 8 %i",
+                     id, hour, minute, portions);
+            id(miot_main).queue_command(cmd);
+            // Manually refresh the feed plan afterwards
+            id(miot_main).queue_command("action 5 6 11 0");
+    # Edit a scheduled feeding time in MCU memory
+    - service: edit_scheduled_feed
+      variables:
+        id: int
+        hour: int
+        minute: int
+        portions: int
+      then:
+        - lambda: |
+            char cmd[512];
+            snprintf(cmd, sizeof(cmd), "action 5 8 10 %i 6 %i 7 %i 8 %i",
+                     id, hour, minute, portions);
+            id(miot_main).queue_command(cmd);
+            // Manually refresh the feed plan afterwards
+            id(miot_main).queue_command("action 5 6 11 0");
+    # Remove a scheduled feeding time from MCU memory
+    - service: remove_scheduled_feed
+      variables:
+        id: int
+      then:
+        - lambda: |
+            char cmd[512];
+            snprintf(cmd, sizeof(cmd), "action 5 9 10 %i", id);
+            id(miot_main).queue_command(cmd);
+            // Manually refresh the feed plan afterwards
+            id(miot_main).queue_command("action 5 6 11 0");
+
+ota:
+  password: !secret feeder_ota_password
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    ssid: "Pet-Feeder Fallback Hotspot"
+    password: !secret feeder_ap_password
+
+captive_portal:
+    
+uart:
+  tx_pin: GPIO15
+  rx_pin: GPIO13
+  baud_rate: 115200
+
+miot:
+  id: miot_main
+
+switch:
+  - platform: "miot"
+    miot_siid: 3
+    miot_piid: 1
+    miot_true: "1"
+    miot_false: "0"
+    name: "Indicator Lights"
+    icon: mdi:lightbulb
+    entity_category: config
+  - platform: "miot"
+    miot_siid: 5
+    miot_piid: 5
+    miot_true: "1"
+    miot_false: "0"
+    name: "Feeding Schedule"
+    icon: mdi:calendar-badge
+    entity_category: config
+  - platform: "miot"
+    miot_siid: 6
+    miot_piid: 1
+    miot_true: "1"
+    miot_false: "0"
+    name: "Child Lock"
+    icon: mdi:lock
+    inverted: yes
+    entity_category: config
+
+binary_sensor:
+  - platform: "miot"
+    miot_siid: 4
+    miot_piid: 8
+    miot_true: "1"
+    miot_false: "0"
+    name: "Top Lid"
+    device_class: opening
+  - platform: "miot"
+    miot_siid: 4
+    miot_piid: 9
+    miot_true: "1"
+    miot_false: "0"
+    name: "Food Door"
+    device_class: opening
+
+text_sensor:
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 1
+    name: "Faults"
+    icon: mdi:chili-alert
+    entity_category: diagnostic
+    filters:
+      - map:
+        - "0 -> No Faults"
+        - "1 -> OK"
+        - "3 -> Error"
+        - "5 -> Timeout"
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 6
+    name: "Food Level"
+    icon: mdi:cup
+    filters:
+      - map:
+        - "0 -> Normal"
+        - "1 -> Low"
+        - "2 -> Empty"
+  - platform: "miot"
+    miot_siid: 4
+    miot_piid: 5
+    name: "Last Feed Source ID"
+    icon: mdi:food-apple
+    filters:
+      - map:
+        - "255 -> Manual"
+  # FeedID,Hour,Minute,Portions,(Dispensed=0,Pending=255) x5
+  - platform: "miot"
+    miot_siid: 5
+    miot_piid: 12
+    miot_poll: false
+    name: "Raw Feed Plan"
+    entity_category: diagnostic
+    icon: mdi:calendar
+
+number:
+  - platform: "miot"    
+    miot_siid: 9
+    miot_piid: 12
+    name: "Phone Timezone"
+    icon: mdi:clock
+    entity_category: config
+    step: 1
+    min_value: -12
+    max_value: 12
+  - platform: "miot"    
+    miot_siid: 9
+    miot_piid: 13
+    name: "Device Country"
+    icon: mdi:clock
+    entity_category: config
+    step: 1
+    min_value: 0
+    max_value: 255
+
+sensor:
+  - platform: "miot"
+    miot_siid: 4
+    miot_piid: 4
+    name: "Last Feed Portions"
+    icon: mdi:food-apple
+  - platform: "miot"
+    miot_siid: 8
+    miot_piid: 1
+    name: "Feeder Clean Timer"
+    unit_of_measurement: days
+    icon: mdi:broom
+  - platform: "miot"
+    miot_siid: 11
+    miot_piid: 2
+    name: "Dessicant Replace Timer"
+    unit_of_measurement: days
+    icon: mdi:air-filter
+
+button:
+  - platform: "miot"
+    miot_siid: 2
+    miot_aiid: 1
+    miot_action_args: '5 ${dispense_food_portions}'
+    name: "Dispense Food"
+    icon: mdi:food-apple
+  - platform: "miot"
+    miot_siid: 8
+    miot_aiid: 1
+    name: "Reset Clean Timer"
+    icon: mdi:restart
+  - platform: "miot"
+    miot_siid: 11
+    miot_aiid: 1
+    name: "Reset Dessicant Timer"
+    icon: mdi:restart

--- a/config/mmgg.feeder.fi1.yaml
+++ b/config/mmgg.feeder.fi1.yaml
@@ -1,5 +1,10 @@
 # https://home.miot-spec.com/spec/mmgg.feeder.fi1
+# 
 # TODO: Automatically adjust "phon-timezone" based on home assistant time for DST.
+# 
+# Home Assistant schedule card for this config available at:
+# https://github.com/cristianchelu/dispenser-schedule-card
+
 external_components:
   source: github://dhewg/esphome-miot@main
 
@@ -120,6 +125,7 @@ api:
         - script.execute: refresh_feed_plan
 
 ota:
+  - platform: esphome
     password: !secret feeder_ota_password
 
 wifi:

--- a/config/mmgg.feeder.fi1.yaml
+++ b/config/mmgg.feeder.fi1.yaml
@@ -16,6 +16,11 @@ esphome:
     name: "dhewg.esphome-miot"
     version: "mmgg.feeder.fi1"
 
+time:
+  - platform: homeassistant
+    id: homeassistant_time
+    timezone: GMT0
+
 esp8266:
   board: esp_wroom_02
 

--- a/config/mmgg.feeder.fi1.yaml
+++ b/config/mmgg.feeder.fi1.yaml
@@ -15,7 +15,7 @@ substitutions:
   # "Dispense Food" button portions (1 ~ 30).
   dispense_food_portions: "1"
 
-scripts:
+script:
   - id: refresh_feed_plan
     then:
       - lambda: id(miot_main).execute_action(5, 6, "11 0");
@@ -39,7 +39,7 @@ time:
         minutes: 1 # buffer to make sure MCU schedule has been refreshed
         seconds: 0
         then:
-          - execute-script: refresh_feed_plan
+          - script.execute: refresh_feed_plan
           - globals.set: 
               id: portions_dispensed_today
               value: "0"
@@ -59,7 +59,7 @@ api:
   on_client_connected:
     then:
       # Refresh the feed plan when HA connects
-      - execute-script: refresh_feed_plan
+      - script.execute: refresh_feed_plan
   services:
     # DEBUG ONLY: Send **arbitrary commands** to MCU from HA
     - service: mcu_command
@@ -70,7 +70,7 @@ api:
     # Refresh the "Raw Feed Plan" sensor on demand
     - service: refresh_feed_plan
       then:
-        - execute-script: refresh_feed_plan
+        - script.execute: refresh_feed_plan
     # Dispense the specified amount of portions
     - service: dispense_food
       variables:
@@ -89,7 +89,7 @@ api:
             id(miot_main).queue_command(
               "action 5 7 10 %i 6 %i 7 %i 8 %i",
               id, hour, minute, portions);
-        - execute-script: refresh_feed_plan
+        - script.execute: refresh_feed_plan
     # Edit a scheduled feeding time in MCU memory
     - service: edit_scheduled_feed
       variables:
@@ -102,14 +102,14 @@ api:
             id(miot_main).queue_command(
               "action 5 8 10 %i 6 %i 7 %i 8 %i",
               id, hour, minute, portions);
-        - execute-script: refresh_feed_plan
+        - script.execute: refresh_feed_plan
     # Remove a scheduled feeding time from MCU memory
     - service: remove_scheduled_feed
       variables:
         id: int
       then:
         - lambda: id(miot_main).queue_command("action 5 9 10 %i", id);
-        - execute-script: refresh_feed_plan
+        - script.execute: refresh_feed_plan
 
 ota:
   password: !secret feeder_ota_password
@@ -221,7 +221,7 @@ text_sensor:
     name: "Raw Feed Plan"
     id: raw_feed_plan
     icon: mdi:calendar-clock
-    polling_interval: never
+    update_interval: never
     entity_category: diagnostic
     lambda: |-
       std::string feeding_schedule;
@@ -334,6 +334,7 @@ event:
   - platform: "miot"
     miot_siid: 4
     miot_eiid: 1
+    id: feedsuccess_event
     event_type: feedsuccess
     internal: true
     on_event:
@@ -347,10 +348,11 @@ event:
           id: portions_dispensed_today_sensor
       # Update "Dispensed" status on the UI
       - delay: 500ms
-      - execute-script: refresh_feed_plan
+      - script.execute: refresh_feed_plan
   - platform: "miot"
     miot_siid: 4
     miot_eiid: 2
+    id: feedstats_event
     event_type: feedstats
     internal: true
     on_event:
@@ -360,6 +362,7 @@ event:
   - platform: "miot"
     miot_siid: 4
     miot_eiid: 3
+    id: feedstart_event
     event_type: feedstart
     internal: true
     on_event:
@@ -367,4 +370,4 @@ event:
           id: feed_event
           event_type: "start"
       # Update "Dispensing" status on the UI
-      - execute-script: refresh_feed_plan
+      - script.execute: refresh_feed_plan

--- a/config/mmgg.feeder.fi1.yaml
+++ b/config/mmgg.feeder.fi1.yaml
@@ -275,7 +275,7 @@ number:
     min_value: -12
     max_value: 12
     mode: box
-    unit_of_measurement: hours
+    unit_of_measurement: h
   - platform: template
     id: dispense_food_portions
     name: "Dispense Amount"
@@ -303,13 +303,17 @@ sensor:
     miot_siid: 8
     miot_piid: 1
     name: "Feeder Clean Timer"
-    unit_of_measurement: days
+    unit_of_measurement: d
+    state_class: measurement
+    device_class: duration
     icon: mdi:broom
   - platform: "miot"
     miot_siid: 11
     miot_piid: 2
     name: "Dessicant Replace Timer"
-    unit_of_measurement: days
+    unit_of_measurement: d
+    state_class: measurement
+    device_class: duration
     icon: mdi:air-filter
   - platform: "miot"    
     miot_siid: 9

--- a/config/mmgg.feeder.fi1.yaml
+++ b/config/mmgg.feeder.fi1.yaml
@@ -36,15 +36,19 @@ time:
     id: homeassistant_time
     timezone: GMT0
     on_time: 
-      # Every day at 00:01:00
-      - hours: 0
-        minutes: 1 # buffer to make sure MCU schedule has been refreshed
-        seconds: 0
+      - hours: "*"
+        minutes: 0
+        seconds: 30
         then:
-          - script.execute: refresh_feed_plan
-          - globals.set: 
-              id: portions_dispensed_today
-              value: "0"
+          # Refresh the feed plan at midnight in device timezone
+          # with 30 second buffer for potential MCU time drift
+          - lambda: |-
+              int current_hour = id(homeassistant_time).now().hour;
+              int adjusted_hour = current_hour + id(phon_time_zone).state;
+              if (adjusted_hour == 24 || adjusted_hour == 0) {
+                id(refresh_feed_plan).execute();
+                id(portions_dispensed_today) = 0;
+              }
 
 esp8266:
   board: esp_wroom_02
@@ -275,7 +279,8 @@ text_sensor:
       - lambda: id(raw_feed_plan).update();
 
 number:
-  - platform: "miot"    
+  - platform: "miot"
+    id: phon_time_zone
     miot_siid: 9
     miot_piid: 12
     name: "Timezone Offset"

--- a/config/mmgg.feeder.fi1.yaml
+++ b/config/mmgg.feeder.fi1.yaml
@@ -11,15 +11,16 @@ globals:
     restore_value: True
     initial_value: "0"
 
-substitutions:
-  # "Dispense Food" button portions (1 ~ 30).
-  dispense_food_portions: "1"
-
 script:
   - id: refresh_feed_plan
     then:
       - lambda: id(miot_main).execute_action(5, 6, "11 0");
       - lambda: id(miot_main).execute_action(5, 6, "11 1");
+  - id: dispense_food
+    parameters:
+      portions: int
+    then:
+      lambda: id(miot_main).queue_command("action 2 1 5 %i", portions);
 
 esphome:
   name: feeder
@@ -76,7 +77,9 @@ api:
       variables:
         portions: int
       then:
-        - lambda: id(miot_main).queue_command("action 2 1 5 %i", portions);
+        - script.execute: 
+            id: dispense_food
+            portions: !lambda return portions;
     # Add a new scheduled feeding time to MCU memory
     - service: add_scheduled_feed
       variables:
@@ -112,7 +115,7 @@ api:
         - script.execute: refresh_feed_plan
 
 ota:
-  password: !secret feeder_ota_password
+    password: !secret feeder_ota_password
 
 wifi:
   ssid: !secret wifi_ssid
@@ -271,6 +274,17 @@ number:
     step: 1
     min_value: -12
     max_value: 12
+  - platform: template
+    id: dispense_food_portions
+    name: "Dispense portions"
+    icon: mdi:food-apple
+    min_value: 1
+    max_value: 30
+    step: 1
+    optimistic: True
+    restore_value: False
+    initial_value: 1
+    entity_category: config
 
 sensor:
   - platform: "miot"
@@ -305,10 +319,11 @@ sensor:
     lambda: return id(portions_dispensed_today);
 
 button:
-  - platform: "miot"
-    miot_siid: 2
-    miot_aiid: 1
-    miot_action_args: '5 ${dispense_food_portions}'
+  - platform: template
+    on_press: 
+      - script.execute: 
+          id: dispense_food
+          portions: !lambda return id(dispense_food_portions).state;
     name: "Dispense Food"
     icon: mdi:food-apple
   - platform: "miot"

--- a/config/mmgg.feeder.fi1.yaml
+++ b/config/mmgg.feeder.fi1.yaml
@@ -5,7 +5,8 @@ external_components:
 
 globals:
   - id: schedule
-    type: std::map<std::string, std::string>
+    # map<id, {hour, minute, portions, status}>
+    type: std::map<int, std::array<int, 4>>
   - id: portions_dispensed_today
     type: int
     restore_value: True
@@ -228,10 +229,15 @@ text_sensor:
     lambda: |-
       std::string feeding_schedule;
       for (auto &entry : id(schedule)) {
-        if (entry.second.find("255") == 0) {
+        if (entry.second[0] == 255) {
           continue; // Skip empty entries
         }
-        feeding_schedule += entry.first + "," + entry.second + ",";
+        feeding_schedule += str_sprintf("%d,%d,%d,%d,%d,",
+                                        entry.first,
+                                        entry.second[0],
+                                        entry.second[1],
+                                        entry.second[2],
+                                        entry.second[3]);
       }
       if (!feeding_schedule.empty()) {
         feeding_schedule.pop_back(); // Remove the trailing comma
@@ -247,20 +253,24 @@ text_sensor:
     on_value:
       - lambda: |-
           char* token = strtok(x.data(), ",");
-          while (token != NULL) {
-            std::string feed_id = std::string(token);
-            token = strtok(NULL, ",");
-            std::string hour = std::string(token);
-            token = strtok(NULL, ",");
-            std::string minute = std::string(token);
-            token = strtok(NULL, ",");
-            std::string portions = std::string(token);
-            token = strtok(NULL, ",");
-            std::string status = std::string(token);
-            token = strtok(NULL, ",");
           
-            std::string details = hour + "," + minute + "," + portions + "," + status;
-            id(schedule)[feed_id] = details;
+          while (token != NULL) {
+            int feed_id = atoi(token);
+            token = strtok(NULL, ",");
+            
+            int hour = atoi(token);
+            token = strtok(NULL, ",");
+            
+            int minute = atoi(token);
+            token = strtok(NULL, ",");
+            
+            int portions = atoi(token);
+            token = strtok(NULL, ",");
+            
+            int status = atoi(token);
+            token = strtok(NULL, ",");
+
+            id(schedule)[feed_id] = {hour, minute, portions, status};
           }
       - lambda: id(raw_feed_plan).update();
 

--- a/config/mmgg.feeder.fi1.yaml
+++ b/config/mmgg.feeder.fi1.yaml
@@ -215,15 +215,6 @@ number:
     step: 1
     min_value: -12
     max_value: 12
-  - platform: "miot"    
-    miot_siid: 9
-    miot_piid: 13
-    name: "Device Country"
-    icon: mdi:clock
-    entity_category: config
-    step: 1
-    min_value: 0
-    max_value: 255
 
 sensor:
   - platform: "miot"
@@ -244,6 +235,12 @@ sensor:
     name: "Dessicant Replace Timer"
     unit_of_measurement: days
     icon: mdi:air-filter
+  - platform: "miot"    
+    miot_siid: 9
+    miot_piid: 13
+    name: "Device Country"
+    icon: mdi:clock
+    entity_category: diagnostic
 
 button:
   - platform: "miot"


### PR DESCRIPTION
This PR adds complete support for `mmgg.feeder.fi1` Pet Feeder.

It requires the Event Component PR (#16) to achieve feature parity with the stock firmware, so please review that before merging this.

I'll describe the Miot services first one at a time, and afterwards go through what I've had to do to replicate features implemented in the xiaomi cloud instead of on-device.

#### For the future
The only things remaining that I'd like implemented, but can be handled outside this PR are:

1. Automatic DST time-zone adjustment of the schedule. 
   When daylight savings is in effect, the `phon-timezone` (SIID9/PIID12) can be updated by automation in order to preserve the preset dispense times. This is something that also the stock setup tries to handle (horribly, it required a factory reset each spring/autumn), but I've left a `TODO` comment about this for the future. Not doing anything about DST is already an improvement.
   More details in the corresponding service sections.
2. HomeAssistant UI control of feeding schedule.
   There isn't a "standard" ESPHome <--> HomeAssistant UX for controlling daily scheduled events in a nice way, so I've opted to leave the schedule format (`feddplan-string`) untouched and handle display and editing of feeding times to a custom HA card.
   Again, more details in the proper section.

#### ESP8266 UART Quirk 
This devices uses an ESP8266, which can't reliably handle 2 UARTs at the same time. The built-in serial logger must be disabled
```yaml
logger:
  baud_rate: 0
```
in order to avoid occasional errors like this:
```bash
Timeout while receiving from MCU, dropping message 'get_do???'
```


# Mi IoT Spec implementation

General observation: Parameters that are listed as input or output of actions are not usable by themselves. They only appear in the `result` message of an action or used in the `action` message.

## Device Info (SIID: 1)
Nothing is sent on 1:1 ~ 1:5 on power cycle.

## Feeder (SIID: 2)
### Properties
1. `fault` works as expected
5. `feeding-measure` Can be read, but produces garbage. Writing to it directly has no effect. Used as input for the `pet-food-out` action.
6. `pet-food-left-level` Works as expected
### Actions
1. `pet-food-out` Works as expected. Dispenses the specified portions immediately. Optional `feeding-measure` parameter; if left out, dispenses one portion.

## Indicator Light (SIID: 3)
### Properties
1. `on` Read/Write works as expected

## Feed Service (SIID: 4)
### Properties
4. `outfood-num`. Number of dispensed portions in last event. Specs say this is `read|notify`, but really it's only `notify`. The feed started|status|successful events use this to communicate what happened
5. `outfood-id`. Index of scheduled feed that dispensed `outfood-num` portions in last event, or `255` if a manual feed. Specs say this is `read|notify`, but really it's only `notify`. The feed started|status|successful events use this to communicate what happened
8. `outletstatus`. There is a motorized door protecting the dispensing outlet, "for freshness". Can be read. Is notified by `properties_changed`, but only after it's closed; there's no notification when it's opened, not even in the "Feeding Started" event.
9. `doorstatus`. Top Lid of the device. Works as expected, thankfully.

### Events

1. `feedsuccess` when feeding is done, with `outfood-id` representing the trigger and `outfood-num` the total.
2. `feedstats` repeatedly while dispensing, with `outfood-id` representing the trigger and `outfood-num` the current progress of portions.
3. `feedstart` when starting the feed, with only `outfood-id` updated.

## Feeding Schedule (SIID: 5)
There's a 10 slot schedule stored on device for offline / battery powered dispensing, controlled by this service, in combination with the `phon-timezone` property of the device control service.

One slot is sent as `[int id],[int hour],[int minute],[int portions],[int status]` where:
  - `id`   - `0-9` - ID of the slot
  - `hour` - `0-23` - Hour of the slot, as UTC+`phon-timezone` (e.g. if `phon-timezone` is `2`, a value of `12` here means `10 UTC`).
  - `minute` - `0-59` Minute of the slot
  - `portions` - `1-30` Number of portions to be dispensed
  - `status` - Status of the slot at the time of querying. Observed values:
    - `0` Dispensed successfully.
    - `1` Failed to dispense (food stuck, etc.)
    - `254` Dispensing in progress.
    - `255` Pending.

An empty slot is returned as `[int id],255,255,255,255`

Every day at midnight all statuses reset from `0 Dispensed`/`1 Failed` back to `255 Pending`. I didn't have a chance to check if this happens in UTC or UTC+`phon_timezone`

Example: `2,12,30,5,0` - Slot 2, at 12:30 dispense 5 portions, dispensed successfuly for today.

The time order of the slots does not matter, i.e. slot 1 can be 1pm while slot 2 9am, and 2 will be dispensed before 1.

There can be empty slots between filled slots without errors.

Ther entire schedule can be queried in two steps by the `getfeedplan` action.

### Properties
5. `feedplan-contr`. Enable or disable the automatic feeding schedule. Works as expected.
6. `feedplan-hour` - named parameter for `feedlist{add,edit,del}` actions
7. `feedplan-min` - named parameter for `feedlist{add,edit,del}` actions
8. `feedplan-unit` - portions to be dispensed, named parameter for `feedlist{add,edit,del}` actions
9. `feedplan-stat` - unused. Seems to be the `status` of the schedule item, but setting it in a `feedlist-` action does not override the item's status.
10. `feedplan-id` - named parameter for `feedlist{add,edit,del}` actions
11. `getfeedplan-num` - named parameter for `getfeedplan` action to control which "page" to return
12. `feddplan-string` - named return value of the `getfeedplan` action.

### Actions
5. `stopfeed`. Unknown, didn't try. Marks `feedplan-contr` as named parameter, but the control is switchable by itself, making this action redundant.
6. `getfeedplan` - Get schedule. Usage `action 5 6 11 0` or `action 5 6 11 1`, and returns the first 5 or last 5 schedules in the `feddplan-string` property as output. Example:
   ```console
   // Get page 0 of schedule. (schedules 0-4)
   [15:04:28][V][miot:189]: Sending reply 'down action 5 6 11 0' to MCU
   [15:04:28][V][miot:095]: Received MCU message 'result 5 6 0 12 "0,6,0,5,0,1,10,0,5,0,2,255,255,255,255,3,255,255,255,255,4,255,255,255,255"'
   
   // Get page 1 of schedule. (schedules 5-9)
   [15:05:06][V][miot:189]: Sending reply 'down action 5 6 11 1' to MCU
   [15:05:06][V][miot:095]: Received MCU message 'result 5 6 0 12 "5,255,255,255,255,6,255,255,255,255,7,255,255,255,255,8,255,255,255,255,9,255,255,255,255"'
   ```
   
   In order to expose all 10 slots in one sensor, I keep each individual slot in a global ~`std::map<std::string, std::string>`~ `std::map<int, std::array<int, 4>>`, updated whenever the `feddplan-string` changes, and reconstruct the full string from it in the `raw_feed_plan` template sensor. I also exclude the empty slots from it for brevity's sake.

   Also, to always have the statuses up to date, I refresh this sensor at the `feedstart` and `feedsuccess` events and after midnight.

   - Also exposed to HA as `refresh_feed_plan` service

5. `feedlistadd` - add a new schedule to slot `feedplan-id`. Specifying an already occupied slot id edits it without an error.
   - exposed to HA as `add_scheduled_feed` service
6. `feedlistedit` - edit the schedule in slot `feedplan-id`
   - exposed to HA as `edit_scheduled_feed` service
7. `feedlistdel` - clear the schedule in slot `feedplan-id`.
   - exposed to HA as `remove_scheduled_feed` service

## Child Lock (SIID: 6)
Everything works as expected.

## Cleaning Reminder (SIID: 8)
Everything works as expected.

## Device Control (SIID:9)

### Properties
11. `factory-result`. Did not test. Specs say `read|notify` but I expect is only an output for the `prtest` action
12. `phon-time-zone`. GMT offset in hours of the schedule times. It's effectively the "Device time zone".

    Changing this number does not also modify the hour numbers set in the schedule, but affects the actual dispensing time.

    Also, since this is an integer, users in countries with [30/45 minute TZ offet](https://www.timeanddate.com/time/time-zones-interesting.html) will never see the proper time.
13. `countrycode`. Unknown if this is useful. Possibly related to the server (de/cn/us/etc) and region-locking. Values unknown, mine returns to `3` after a minute whatever I set it to `read|write|notify` works.

### Actions
1. `prtest` did not test. I didn't want to risk damage to my device, as I don't know under what conditions this needs to be performed in the factory.
2. `set-phone-time-zone` did not test. The mentioned `phon-time-zone` can be set directly.
3. `set-countrycode` has the same effect as setting the `countrycode` directly, and for my device it always returns to `3` eventually.

### Events

1. `wifioff` wall power loss, ESP will be powered off in 30s to preserve battery.

   If the power is restored within the 30s there is no further event sent and nothing happens.

   I tried making use of this to gracefully shutdown the esp, but if the power is restored before it's powered off it would be stuck in the poweroff state.

## Replace Dessicant Reminder (SIID: 11)
Everything works as expected.

# Extra features

I've added a `dispense_food_portions` template number to control how much is dispensed by the `dispense_food` button, for easier usage.

Also available in HA as a `dispense_food` service 

The `Portions Dispensed Today` total counter is also implemented on-device. After each `feedsuccess` event the counter is incremented, and reset at midnight.

# Device Screenshots

| ![mmgg feeder fi1 control](https://github.com/user-attachments/assets/8483b181-8c00-459c-9e71-55768b5cfade) | ![mmgg feeder fi1 sensor](https://github.com/user-attachments/assets/2a02a8eb-02c5-4a8e-82dd-cfa6d244221d) | ![mmgg feeder fi1 events](https://github.com/user-attachments/assets/507f0909-29e3-4f9d-8edd-7aab92879123) |
|-|-|-|
| ![mmgg feeder fi1 diagnostics](https://github.com/user-attachments/assets/e66ea4c6-d9f1-4394-b739-0a83378d8d8f) | ![mmgg feeder fi1 configuration](https://github.com/user-attachments/assets/51af1d29-9719-4988-9b02-65383573dd2d) | ![mmgg feeder fi1 example](https://github.com/user-attachments/assets/ba831c74-d372-479a-8297-b357f1f27564) |

The last screenshot demonstrates a HA-side custom card to view/edit the schedule in the UI.

~I'll try to publish it separately once it's finished, but with this, the device should be fully controllable in Home Assistant.~
The schedule edit card is available here: https://github.com/cristianchelu/dispenser-schedule-card