### PR TITLE
fix ota compile error for esphome > v24.6.0

### DIFF
--- a/components/miot/miot.cpp
+++ b/components/miot/miot.cpp
@@ -15,7 +15,7 @@
 #endif
 
 #ifdef USE_OTA
-#include "esphome/components/ota/ota_component.h"
+#include "esphome/components/ota/ota_backend.h"
 #endif
 
 #ifdef USE_TIME
@@ -61,17 +61,18 @@ void Miot::setup() {
     });
 
 #ifdef USE_OTA
-  ota::global_ota_component->add_on_state_callback([this](ota::OTAState state, float progress, uint8_t error) {
-    switch (state) {
-    case ota::OTA_STARTED:
-      // directly send this to indicate a firmware update, as loop() won't get called anymore
-      send_reply_("down MIIO_net_change updating");
-      break;
-    case ota::OTA_ERROR:
-      queue_net_change_command(true);
-      break;
-    default:
-      break;
+  ota::get_global_ota_callback()->add_on_state_callback(
+    [this](ota::OTAState state, float progress, uint8_t error, ota::OTAComponent *comp) {
+      switch (state) {
+      case ota::OTA_STARTED:
+        // directly send this to indicate a firmware update, as loop() won't get called anymore
+        send_reply_("down MIIO_net_change updating");
+        break;
+      case ota::OTA_ERROR:
+        queue_net_change_command(true);
+        break;
+      default:
+        break;
     }
   });
 #endif


### PR DESCRIPTION
This is an alternate solution for the OTA compile error addressed in #24 making use of the new esphome function `get_global_ota_callback` based on how the changes in the OTA component are [handled](https://github.com/esphome/esphome/blob/4c6a17e304002b741388335db30c06725a6730c6/esphome/components/esp32_ble_tracker/esp32_ble_tracker.cpp#L64) in the esphome codebase.