### PR TITLE
add example `dmaker.fan.p18` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Device | Model Version | Wiki | ESPHome Config | MIoT Specification
 Mi Air Purifier 3C | zhimi.airp.mb4a <br> zhimi.airpurifier.mb4 |[link](../../wiki/Xiaomi-Mi-Air-Purifier-3C) | [zhimi.airp.mb4a](config/zhimi.airp.mb4a.yaml) | [link](https://home.miot-spec.com/spec/zhimi.airp.mb4a) <br> [link](https://home.miot-spec.com/spec/zhimi.airpurifier.mb4)
 Xiaomi Smart Air Purifier 4 | zhimi.airp.mb5 | [link](../../wiki/Xiaomi-Smart-Air-Purifier-4) | [zhimi.airp.mb5](config/zhimi.airp.mb5.yaml) | [link](https://home.miot-spec.com/spec/zhimi.airp.mb5)
 Xiaomi Smart Air Purifier 4 Lite | zhimi.airp.rmb1 | [link](../../wiki/Xiaomi-Smart-Air-Purifier-4-Lite-(zhimi.airp.rmb1)) | [zhimi.airp.rmb1](config/zhimi.airp.rmb1.yaml) | [link](https://home.miot-spec.com/spec/zhimi.airp.rmb1)
+Xiaomi Mi Smart Standing Fan 2 | dmaker.fan.p18 |  | [dmaker.fan.p18](config/dmaker.fan.p18.yaml) | [link](https://home.miot-spec.com/spec/dmaker.fan.p18)
 
 Some of the devices has more than one model versions (like Mi Air Purifier 3C). If their MIoT specifications are identical, the ESPHome config will be compatible with all of them.
 

--- a/config/dmaker.fan.p18.yaml
+++ b/config/dmaker.fan.p18.yaml
@@ -157,6 +157,7 @@ number:
     name: "Off Delay"
     icon: "mdi:clock-outline"
     unit_of_measurement: "min"
+    device_class: duration
     min_value: 0
     max_value: 480
     step: 1

--- a/config/dmaker.fan.p18.yaml
+++ b/config/dmaker.fan.p18.yaml
@@ -1,0 +1,149 @@
+# https://home.miot-spec.com/spec/dmaker.fan.p18
+
+external_components:
+  source: github://dhewg/esphome-miot@main
+
+esphome:
+  name: standing-fan
+  friendly_name: Smart Standing Fan 2
+  comment: Xiaomi Mi Smart Standing Fan 2 (dmaker.fan.p18)
+  project:
+    name: "dhewg.esphome-miot"
+    version: "dmaker.fan.p18"
+
+esp8266:
+  board: esp_wroom_02
+  framework:
+    version: recommended
+
+logger:
+  level: DEBUG
+  # Important: Disable UART1 logging to avoid hardware errors on main UART0
+  baud_rate: 0
+
+api:
+  encryption:
+    key: !secret api_encryption_key
+  reboot_timeout: 0s
+  services:
+    - service: mcu_command
+      variables:
+        command: string
+      then:
+        - lambda: 'id(miot_main).queue_command(command);'
+
+ota:
+  - platform: esphome
+    password: !secret ota_password
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    password: !secret wifi_ap_password
+
+captive_portal:
+
+uart:
+  tx_pin: GPIO15
+  rx_pin: GPIO13
+  baud_rate: 115200
+
+miot:
+  id: miot_main
+
+switch:
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 1
+    name: "Power"
+    icon: "mdi:power"
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 4
+    name: "Oscillation"
+    icon: "mdi:arrow-oscillating"
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 7
+    name: "Indicator Lights"
+    icon: "mdi:lightbulb"
+    entity_category: config
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 8
+    name: "Notification Sounds"
+    icon: "mdi:volume-high"
+    entity_category: config
+  - platform: "miot"
+    miot_siid: 3
+    miot_piid: 1
+    name: "Child Lock"
+    icon: "mdi:lock"
+    entity_category: config
+  
+select:
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 3
+    name: "Mode"
+    icon: "mdi:leaf"
+    options:
+      0: "Direct Breeze"
+      1: "Natural Breeze"
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 5
+    name: "Oscillation Angle"
+    icon: "mdi:angle-obtuse"
+    options:
+      30: "30°"
+      60: "60°"
+      90: "90°"
+      120: "120°"
+      140: "140°"
+
+number:
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 2
+    name: "Fan Level"
+    icon: "mdi:fan-chevron-up"
+    min_value: 1
+    max_value: 4
+    step: 1
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 6
+    name: "Off Delay"
+    icon: "mdi:clock-outline"
+    unit_of_measurement: "min"
+    min_value: 0
+    max_value: 480
+    step: 1
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 10
+    name: "Fan Speed"
+    icon: "mdi:speedometer"
+    min_value: 1
+    max_value: 100
+    step: 1
+    unit_of_measurement: "%"
+
+button:
+  - platform: "miot"
+    miot_siid: 2
+    miot_aiid: 1
+    name: "Toggle Power"
+    icon: "mdi:power-cycle"
+  - platform: "template"
+    name: "Adjust Left"
+    icon: "mdi:pan-left"
+    on_press: 
+      - lambda: id(miot_main).queue_command("set_properties 2 9 1");
+  - platform: "template"
+    name: "Adjust Right"
+    icon: "mdi:pan-right"
+    on_press: 
+      - lambda: id(miot_main).queue_command("set_properties 2 9 2");

--- a/config/dmaker.fan.p18.yaml
+++ b/config/dmaker.fan.p18.yaml
@@ -54,15 +54,46 @@ miot:
 
 switch:
   - platform: "miot"
+    id: "on"
     miot_siid: 2
     miot_piid: 1
     name: "Power"
     icon: "mdi:power"
+    on_turn_off:
+      - lambda: |- 
+          if(id(template_fan).state == true) {
+            auto call = id(template_fan).turn_off();
+            call.perform();
+          }
+    on_turn_on:
+      - lambda: |- 
+          if(id(template_fan).state == false) {
+            auto call = id(template_fan).turn_on();
+            call.perform();
+          }
   - platform: "miot"
+    id: "horizontal_swing"
     miot_siid: 2
     miot_piid: 4
     name: "Oscillation"
     icon: "mdi:arrow-oscillating"
+    on_turn_off:
+      - lambda: |-
+          if (id(template_fan).oscillating == true) {
+            auto call = id(template_fan).make_call();
+            call.set_oscillating(false);
+            call.set_preset_mode(id(mode).state.c_str());
+            call.perform();
+          }
+    on_turn_on:
+      - lambda: |-
+          if (id(template_fan).oscillating == false) {
+            auto call = id(template_fan).make_call();
+            call.set_oscillating(true);
+            call.set_preset_mode(id(mode).state.c_str());
+            call.perform();
+          }
+
   - platform: "miot"
     miot_siid: 2
     miot_piid: 7
@@ -84,6 +115,7 @@ switch:
   
 select:
   - platform: "miot"
+    id: "mode"
     miot_siid: 2
     miot_piid: 3
     name: "Mode"
@@ -91,6 +123,13 @@ select:
     options:
       0: "Direct Breeze"
       1: "Natural Breeze"
+    on_value:
+      - lambda: |-
+          if(id(template_fan).preset_mode != x) {
+            auto call = id(template_fan).make_call();
+            call.set_preset_mode(x.c_str());
+            call.perform();
+          }
   - platform: "miot"
     miot_siid: 2
     miot_piid: 5
@@ -122,6 +161,7 @@ number:
     max_value: 480
     step: 1
   - platform: "miot"
+    id: "speed_level"
     miot_siid: 2
     miot_piid: 10
     name: "Fan Speed"
@@ -130,6 +170,12 @@ number:
     max_value: 100
     step: 1
     unit_of_measurement: "%"
+    on_value:
+      - lambda: |-
+          auto call = id(template_fan).make_call();
+          call.set_speed(x);
+          call.set_preset_mode(id(mode).state.c_str());
+          call.perform();
 
 button:
   - platform: "miot"
@@ -157,3 +203,44 @@ button:
     icon: "mdi:fan"
     miot_siid: 4
     miot_aiid: 2
+
+fan:
+  - platform: "template"
+    id: template_fan
+    name: None
+    has_oscillating: true
+    speed_count: 100
+    preset_modes:
+      - "Direct Breeze"
+      - "Natural Breeze"
+    restore_mode: NO_RESTORE
+    on_turn_on:
+      - lambda: if (id(on).state == false) id(on).turn_on();
+    on_turn_off:
+      - lambda: if (id(on).state == true) id(on).turn_off();
+    on_oscillating_set:
+      - lambda: |-
+          if (id(horizontal_swing).state != x) {
+            if (x == true) {
+              id(horizontal_swing).turn_on();
+            } else {
+              id(horizontal_swing).turn_off();
+            }
+          }
+          auto call = id(template_fan).make_call();
+          call.set_preset_mode(id(mode).state.c_str());
+          call.perform();
+    on_speed_set:
+      - lambda: |-
+          if (id(speed_level).state != x) {
+            auto call = id(speed_level).make_call();
+            call.set_value(x);
+            call.perform();
+          }
+    on_preset_set:
+      - lambda: |-
+          if (x != "" && id(mode).state != x) {
+            auto call = id(mode).make_call();
+            call.set_option(x);
+            call.perform();
+          }

--- a/config/dmaker.fan.p18.yaml
+++ b/config/dmaker.fan.p18.yaml
@@ -147,3 +147,13 @@ button:
     icon: "mdi:pan-right"
     on_press: 
       - lambda: id(miot_main).queue_command("set_properties 2 9 2");
+  - platform: "miot"
+    name: "Toggle Mode"
+    icon: "mdi:leaf"
+    miot_siid: 4
+    miot_aiid: 1
+  - platform: "miot"
+    name: "Toggle Speed"
+    icon: "mdi:fan"
+    miot_siid: 4
+    miot_aiid: 2


### PR DESCRIPTION
This PR adds complete support for Xiaomi Smart Standing Fan 2 (dmaker.fan.p18).

There is no serial number, device, or other information provided on hidden SIID 1.

## Quirks
The only quirk of this device is that they decided to implement what should have been two actions as one write-only property for the manual left-right adjustment:

```yaml
  - platform: "template"
    name: "Adjust Left"
    icon: "mdi:pan-left"
    on_press: 
      - lambda: id(miot_main).queue_command("set_properties 2 9 1");
  - platform: "template"
    name: "Adjust Right"
    icon: "mdi:pan-right"
    on_press: 
      - lambda: id(miot_main).queue_command("set_properties 2 9 2");
```
Reading the `motor control` property  is not allowed
```bash
[12:49:14][D][miot:140]: Queuing MCU command 'get_properties 2 9'
[12:49:14][E][miot:254]: Result error on property 2:9: -4003
```

and setting it to `1: LEFT` or `2: RIGHT` makes the fan turn a few degrees either left or right. Setting to `0: NONE` has no physical interrupt effect, even if setting immediately after a turn command.

Everything else functions intuitively and as intended.

## Fan component

Based on discussions in issue #19 , I've also wired a `Template Fan` component to expose an entity in the `fan.` domain, for better HA integration.

## Screenshots

|![Screenshot from 2024-08-03 21-44-55](https://github.com/user-attachments/assets/2b1a9ef0-6305-48ce-9377-27b74bd14465) | ![Screenshot from 2024-08-03 21-45-09](https://github.com/user-attachments/assets/bf0d6673-54c4-4dc7-b90f-dc7adbdd4724) | ![Screenshot from 2024-08-03 21-45-34](https://github.com/user-attachments/assets/d6fdffe8-8680-4355-907a-0ba82b63c632) |
| ---------- | ------------ | ------------ |
