### PR TITLE
`mmgg.feeder.fi1` improvements

### DIFF
--- a/components/miot/miot.cpp
+++ b/components/miot/miot.cpp
@@ -377,7 +377,9 @@ void Miot::process_message_(char *msg) {
   } else if (cmd == "time") {
     const char *arg = strtok_r(nullptr, " ", &saveptr);
     bool posix = arg && *arg && std::strcmp(arg, "posix") == 0;
-    send_reply_(get_time_reply_(posix).c_str());
+    auto reply = get_time_reply_(posix);
+    ESP_LOGD(TAG, "MCU time request: %s", reply.c_str());
+    send_reply_(reply.c_str());
   } else if (cmd == "mac") {
     send_reply_(get_mac_address().c_str());
   } else if (cmd == "model") {

--- a/config/mmgg.feeder.fi1.yaml
+++ b/config/mmgg.feeder.fi1.yaml
@@ -27,6 +27,11 @@ script:
       portions: int
     then:
       lambda: id(miot_main).queue_command("action 2 1 5 %i", portions);
+  - id: set_countrycode
+    parameters:
+      countrycode: int
+    then:
+      lambda: id(miot_main).queue_command("action 9 5 13 %i", countrycode);
 
 esphome:
   name: feeder
@@ -123,6 +128,14 @@ api:
       then:
         - lambda: id(miot_main).queue_command("action 5 9 10 %i", id);
         - script.execute: refresh_feed_plan
+    # Set device country code
+    - service: set_countrycode
+      variables:
+        countrycode: int
+      then:
+        - script.execute: 
+            id: set_countrycode
+            countrycode: !lambda return countrycode;
 
 ota:
   - platform: esphome
@@ -336,12 +349,18 @@ sensor:
     state_class: measurement
     device_class: duration
     icon: mdi:air-filter
-  - platform: "miot"    
+  - platform: "miot"
+    id: contrycode
     miot_siid: 9
     miot_piid: 13
     name: "Device Country"
     icon: mdi:clock
     entity_category: diagnostic
+    on_raw_value: # https://github.com/dhewg/esphome-miot/issues/39
+      lambda: |-
+        if (x == 255) {
+          id(set_countrycode).execute(3);
+        }
   - platform: "template"
     name: "Dispensed Today"
     id: dispensed_today

--- a/config/mmgg.feeder.fi1.yaml
+++ b/config/mmgg.feeder.fi1.yaml
@@ -267,7 +267,7 @@ text_sensor:
         if (entry.second[0] == 255) {
           continue; // Skip empty entries
         }
-        feeding_schedule += str_sprintf("%d,%d,%d,%d,%d,",
+        feeding_schedule += str_sprintf("%d,%d,%d,%d,%d ",
                                         entry.first,
                                         entry.second[0],
                                         entry.second[1],

--- a/config/mmgg.feeder.fi1.yaml
+++ b/config/mmgg.feeder.fi1.yaml
@@ -310,7 +310,6 @@ text_sensor:
       - lambda: id(raw_feed_plan).update();
   - platform: "template"
     name: "Device Timezone"
-    id: timezone
     icon: mdi:clock
     entity_category: diagnostic
     lambda: return {"${auto_dst_timezone}"};
@@ -369,7 +368,6 @@ sensor:
             id(miot_main).queue_command("action 9 4 12 %i", id(auto_dst_offset));
           }
   - platform: "miot"
-    id: contrycode
     miot_siid: 9
     miot_piid: 13
     name: "Device Country"

--- a/config/mmgg.feeder.fi1.yaml
+++ b/config/mmgg.feeder.fi1.yaml
@@ -1,18 +1,27 @@
 # https://home.miot-spec.com/spec/mmgg.feeder.fi1
 # 
-# TODO: Automatically adjust "phon-timezone" based on home assistant time for DST.
-# 
 # Home Assistant schedule card for this config available at:
 # https://github.com/cristianchelu/dispenser-schedule-card
 
 external_components:
   source: github://dhewg/esphome-miot@main
 
+substitutions:
+  # Timezone for automatic daylight savings time (DST) adjustment
+  # See https://en.wikipedia.org/wiki/List_of_tz_database_time_zones for options
+  # Change as needed for your location
+  # e.g. "Europe/London", "America/New_York", "Asia/Tokyo"
+  auto_dst_timezone: "Etc/GMT" 
+
 globals:
   - id: schedule
     # map<id, {hour, minute, portions, status}>
     type: std::map<int, std::array<int, 4>>
   - id: portions_dispensed_today
+    type: int
+    restore_value: True
+    initial_value: "0"
+  - id: auto_dst_offset
     type: int
     restore_value: True
     initial_value: "0"
@@ -44,7 +53,10 @@ esphome:
 time:
   - platform: homeassistant
     id: homeassistant_time
-    timezone: GMT0
+    timezone: ${auto_dst_timezone}
+    on_time_sync:
+      lambda: |-
+        id(auto_dst_offset) = id(homeassistant_time).now().timezone_offset() / 3600;
     on_time: 
       - hours: "*"
         minutes: 0
@@ -53,7 +65,7 @@ time:
           # Refresh the feed plan at midnight in device timezone
           # with 30 second buffer for potential MCU time drift
           - lambda: |-
-              int current_hour = id(homeassistant_time).now().hour;
+              int current_hour = id(homeassistant_time).utcnow().hour;
               int adjusted_hour = current_hour + id(phon_time_zone).state;
               if (adjusted_hour == 24 || adjusted_hour == 0) {
                 id(refresh_feed_plan).execute();
@@ -296,20 +308,14 @@ text_sensor:
             id(schedule)[feed_id] = {hour, minute, portions, status};
           }
       - lambda: id(raw_feed_plan).update();
+  - platform: "template"
+    name: "Device Timezone"
+    id: timezone
+    icon: mdi:clock
+    entity_category: diagnostic
+    lambda: return {"${auto_dst_timezone}"};
 
 number:
-  - platform: "miot"
-    id: phon_time_zone
-    miot_siid: 9
-    miot_piid: 12
-    name: "Timezone Offset"
-    icon: mdi:clock
-    entity_category: config
-    step: 1
-    min_value: -12
-    max_value: 12
-    mode: box
-    unit_of_measurement: h
   - platform: template
     id: dispense_food_portions
     name: "Dispense Amount"
@@ -349,6 +355,19 @@ sensor:
     state_class: measurement
     device_class: duration
     icon: mdi:air-filter
+  - platform: "miot"
+    id: phon_time_zone
+    miot_siid: 9
+    miot_piid: 12
+    name: "Timezone Offset"
+    icon: mdi:clock
+    unit_of_measurement: h
+    entity_category: diagnostic
+    on_value:
+      - lambda: |-
+          if (x != id(auto_dst_offset)) {
+            id(miot_main).queue_command("action 9 4 12 %i", id(auto_dst_offset));
+          }
   - platform: "miot"
     id: contrycode
     miot_siid: 9


### PR DESCRIPTION
This PR includes 4 changes, in 4 commits:

## add debug log for mcu time request
While debugging time-related issues, I had the need to validate that the MCU was actually requesting and receiving the correct time. 

This is already logged by the `VERBOSE` level, but keeping the log open for ~1 hour to catch the MCU requesting this will eat memory+cpu on the browser very quickly. 

Just adding it on the `DEBUG` level seems useful to have. I can separate / remove this part from the PR if you want.

## `mmgg.feeder.fi1` changes

- Based on investigations, it seems virgin devices flashed directly with ESPHome are missing some intialization in the `contrycode` (Siid: 9, Piid: 13) parameter, making the scheduler not work. This initializes it with a known good value. Fixes #39 .
- Adds automatic DST adjustment and control of the `phon_time_zone` timezone offset parameter. I experimented a few iterations to make the auto-adjustment optional, but in the end decided it's not worth it.
  - Device timezone is now a compile-time decision only via the `auto_dst_timezone` substitution. I tried exposing this as a text component, but at runtime, ESPHome can only handle explicit declarations in the form `EET-2EEST,M3.5.0/3,M10.5.0/4` instead of human-readable `Europe/Bucharest` that are available at compile time. This means that while we could change the TZ at runtime, it would be cumbersome, and let's be honest, how often do people change timezones without some change to their smart home config? :)
  - `phon_time_zone` becomes a read-only diagnostic sensor. Allowing a manual override would mean adding a switch for "Auto-DST" logic, and since the timezone is not easily runtime-changeable, again, there is little benefit for the added complexity.
  - Additionally for the `phon_time_zone`, seeing as there's a `set-phone-time-zone` action, as well as the property itself being writeable, there might be some slight differences that could explain the weird behavior described.
- In order to improve the word-break UI for the raw feed plan, I've separated the schedule entries by a space instead of the MCU-style comma. There's no functional differences as it's a diagnostic value only.

