### PR TITLE
Add support for Mi Air Purifier Pro H

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Mi Air Purifier 3C | zhimi.airp.mb4a <br> zhimi.airpurifier.mb4 |[link](../../wi
 Xiaomi Smart Air Purifier 4 | zhimi.airp.mb5 | [link](../../wiki/Xiaomi-Smart-Air-Purifier-4) | [zhimi.airp.mb5](config/zhimi.airp.mb5.yaml) | [link](https://home.miot-spec.com/spec/zhimi.airp.mb5)
 Xiaomi Smart Air Purifier 4 Lite | zhimi.airp.rmb1 | [link](../../wiki/Xiaomi-Smart-Air-Purifier-4-Lite-(zhimi.airp.rmb1)) | [zhimi.airp.rmb1](config/zhimi.airp.rmb1.yaml) | [link](https://home.miot-spec.com/spec/zhimi.airp.rmb1)
 Xiaomi Smart Air Purifier 4 Pro | zhimi.airp.vb4 |  | [zhimi.airp.vb4](config/zhimi.airp.vb4.yaml) | [link](https://home.miot-spec.com/spec?type=urn:miot-spec-v2:device:air-purifier:0000A007:zhimi-vb4:1)
+Mi Air Purifier Pro H | zhimi.airpurifier.vb2 |  | [zhimi.airpurifier.vb2](config/zhimi.airpurifier.vb2.yaml) | [link](https://home.miot-spec.com/spec/zhimi.airpurifier.vb2)
 Smartmi Evaporative Humidifier 2 | zhimi.humidifier.ca4 |  | [zhimi.humidifier.ca4](config/zhimi.humidifier.ca4.yaml) | [link](https://home.miot-spec.com/spec/zhimi.humidifier.ca4)
 Smartmi Air Purifier | zhimi.airpurifier.za1 |  | [zhimi.airpurifier.za1](config/zhimi.airpurifier.za1.yaml) | [link](https://home.miot-spec.com/spec/zhimi.airpurifier.za1)
 Mi Smart Standing Fan 2 | dmaker.fan.p18 |  | [dmaker.fan.p18](config/dmaker.fan.p18.yaml) | [link](https://home.miot-spec.com/spec/dmaker.fan.p18)

--- a/config/zhimi.airpurifier.vb2.yaml
+++ b/config/zhimi.airpurifier.vb2.yaml
@@ -1,0 +1,254 @@
+external_components:
+  source: github://dhewg/esphome-miot@main
+
+esphome:
+  name: purifier_pro_h
+  friendly_name: Air Purifier Pro H
+  comment: Mi Air Purifier Pro H (zhimi.airpurifier.vb2)
+  project:
+    name: "dhewg.esphome-miot"
+    version: "zhimi.airpurifier.vb2"
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+    sdkconfig_options:
+      CONFIG_FREERTOS_UNICORE: y
+    advanced:
+      ignore_efuse_custom_mac: true
+      ignore_efuse_mac_crc: true
+
+logger:
+  level: DEBUG
+
+api:
+  encryption:
+    key: !secret api_encryption_key
+  reboot_timeout: 0s
+  services:
+    - service: mcu_command
+      variables:
+        command: string
+      then:
+        - lambda: 'id(miot_main).queue_command(command);'
+
+ota:
+  - platform: esphome
+    password: !secret ota_password
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    password: !secret wifi_ap_password
+
+captive_portal:
+
+uart:
+  tx_pin: GPIO17
+  rx_pin: GPIO16
+  baud_rate: 115200
+
+miot:
+  id: miot_main
+  miot_heartbeat_siid: 11
+  miot_heartbeat_piid: 4
+
+switch:
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 1
+    name: "Power"
+    icon: mdi:power
+  - platform: "miot"
+    miot_siid: 6
+    miot_piid: 1
+    name: "Notification Sounds"
+    icon: mdi:volume-high
+    entity_category: config
+  - platform: "miot"
+    miot_siid: 8
+    miot_piid: 1
+    name: "Child Lock"
+    icon: mdi:lock
+    entity_category: config
+
+select:
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 4
+    name: "Mode"
+    options:
+      0: "Auto"
+      1: "Sleep"
+      2: "Favorite"
+      3: "Manual"
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 5
+    name: "Fan Level"
+    icon: mdi:fan
+    options:
+      1: "Low"
+      2: "Medium"
+      3: "High"
+  - platform: "miot"
+    miot_siid: 13
+    miot_piid: 2
+    name: "Display Brightness"
+    icon: mdi:brightness-6
+    entity_category: config
+    options:
+      0: "Off"
+      1: "Low"
+      2: "High"
+  - platform: "miot"
+    miot_siid: 14
+    miot_piid: 1
+    name: "Temperature Display Unit"
+    icon: mdi:temperature-celsius
+    entity_category: config
+    options:
+      1: "Celsius"
+      2: "Fahrenheit"
+
+text_sensor:
+  - platform: "miot"
+    miot_siid: 1
+    miot_piid: 5
+    miot_poll: false
+    name: "Serial Number"
+    icon: mdi:numeric
+    entity_category: diagnostic
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 2
+    name: "Device Fault"
+    icon: mdi:fan-alert
+    entity_category: diagnostic
+    filters:
+      - map:
+        - "0 -> No Faults"
+        - "1 -> PM2.5 Sensor Error"
+        - "2 -> Temperature Error"
+        - "3 -> Humidity Error"
+        - "4 -> No Filter Detected"
+
+number:
+  - platform: "miot"
+    miot_siid: 9
+    miot_piid: 2
+    name: "Favorite Speed"
+    icon: mdi:speedometer
+    min_value: 200
+    max_value: 2300
+    step: 1
+  - platform: "miot"
+    miot_siid: 9
+    miot_piid: 4
+    name: "Manual Speed"
+    icon: mdi:speedometer
+    min_value: 0
+    max_value: 2000
+    step: 1
+  - platform: "miot"
+    miot_siid: 9
+    miot_piid: 5
+    name: "Favorite Level"
+    icon: mdi:speedometer
+    min_value: 0
+    max_value: 11
+    step: 1
+
+sensor:
+  - platform: "miot"
+    miot_siid: 3
+    miot_piid: 1
+    name: "Relative Humidity"
+    unit_of_measurement: "%"
+    device_class: humidity
+    state_class: "measurement"
+  - platform: "miot"
+    miot_siid: 3
+    miot_piid: 4
+    name: "PM2.5 Density"
+    unit_of_measurement: "µg/m³"
+    device_class: pm25
+    state_class: "measurement"
+  - platform: "miot"
+    miot_siid: 3
+    miot_piid: 7
+    name: "Temperature"
+    unit_of_measurement: "°C"
+    device_class: temperature
+    accuracy_decimals: 1
+    state_class: "measurement"
+  - platform: "miot"
+    miot_siid: 3
+    miot_piid: 8
+    name: "PM10 Density"
+    unit_of_measurement: "µg/m³"
+    device_class: pm10
+    state_class: "measurement"
+  - platform: "miot"
+    miot_siid: 4
+    miot_piid: 1
+    name: "Filter Life Level"
+    unit_of_measurement: "%"
+    icon: mdi:air-filter
+  - platform: "miot"
+    miot_siid: 4
+    miot_piid: 3
+    name: "Filter Used Time"
+    entity_category: diagnostic
+    unit_of_measurement: "h"
+    icon: mdi:air-filter
+  - platform: "miot"
+    miot_siid: 4
+    miot_piid: 4
+    name: "Filter Lifetime Remaining"
+    entity_category: diagnostic
+    unit_of_measurement: "d"
+    icon: mdi:air-filter
+  - platform: "miot"
+    miot_siid: 9
+    miot_piid: 1
+    name: "Motor Speed"
+    unit_of_measurement: "rpm"
+    icon: mdi:fan
+  - platform: "miot"
+    miot_siid: 11
+    miot_piid: 1
+    name: "Total Purified Volume"
+    unit_of_measurement: "m³"
+    state_class: "measurement"
+  - platform: "miot"
+    miot_siid: 11
+    miot_piid: 2
+    name: "Average AQI"
+    state_class: "measurement"
+
+button:
+  - platform: "miot"
+    miot_siid: 2
+    miot_aiid: 1
+    name: "Toggle Power"
+    icon: mdi:power
+  - platform: "miot"
+    miot_siid: 4
+    miot_aiid: 1
+    miot_action_args: "3 0"
+    name: "Reset Filter Life"
+    icon: mdi:restart
+    entity_category: config
+  - platform: "miot"
+    miot_siid: 9
+    miot_aiid: 1
+    name: "Toggle Mode"
+    icon: mdi:cached
+  - platform: "miot"
+    miot_siid: 9
+    miot_aiid: 2
+    name: "Toggle Fan Level"
+    icon: mdi:approximately-equal


### PR DESCRIPTION
Add support for the Mi Air Purifier Pro H (`zhimi.airpurifier.vb2`).

* **New Configuration File**
  - Add `config/zhimi.airpurifier.vb2.yaml` for the Mi Air Purifier Pro H.
  - Include necessary `external_components`, `esphome`, `esp32`, `logger`, `api`, `ota`, `wifi`, `captive_portal`, `uart`, and `miot` sections.
  - Add `switch`, `select`, `text_sensor`, `number`, `sensor`, and `button` sections based on the MIoT Specification.

* **README Update**
  - Update the "Supported devices" table to include the Mi Air Purifier Pro H.
  - Add a new row for the Mi Air Purifier Pro H with the model version `zhimi.airpurifier.vb2`.
  - Add links to the new configuration file and the MIoT Specification.

