### PR TITLE
Add Xiaomi Smart Tower Fan (dmaker.fan.p39) as unsupported

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Mi Air Purifier 2S | zhimi.airpurifier.mc1 | Proprietary chip | [link](../../wik
 Xiaomi Air Purifier 4 Lite (CN Model) | zhimi.airp.rma3 | No dedicated MCU | [link](../../issues/34)|[link](https://home.miot-spec.com/spec/zhimi.airp.rma3)
 Xiaomi Smart Air Purifier 4 Compact | zhimi.airp.cpa4 | No dedicated MCU | [link](../../issues/22#issuecomment-2137163103)|[link](https://home.miot-spec.com/spec/zhimi.airp.cpa4)
 Smartmi Evaporative Humidifier| zhimi.humidifier.cb1 | Proprietary chip | [link](../../issues/26#issuecomment-2417148320)|[link](https://home.miot-spec.com/spec/zhimi.humidifier.cb1)
+Xiaomi Smart Tower Fan | dmaker.fan.p39 | Proprietary chip | - |[link](https://home.miot-spec.com/spec/dmaker.fan.p39)
 
 ## Building a firmware
 


### PR DESCRIPTION
I've opened Xiaomi Smart Tower Fan (dmaker.fan.p39), but unfortunately it uses propertiary Xiaomi chip ([MHCWB4P-B](https://fcc.report/FCC-ID/2AFZZMHCWB4P-B/4718617.pdf))

![image](https://github.com/user-attachments/assets/435ce90b-d513-4781-bae5-61091ffb6f73)
