### PR TITLE
Default to `error` instead of `ok`

### DIFF
--- a/components/miot/miot.cpp
+++ b/components/miot/miot.cpp
@@ -405,7 +405,7 @@ void Miot::process_message_(char *msg) {
     App.safe_reboot();
   } else {
     ESP_LOGW(TAG, "Unknown command '%s'", cmd.c_str());
-    send_reply_("ok");
+    send_reply_("error");
   }
 }
 


### PR DESCRIPTION
According to spec, `ok` should only be returned when a **valid** command is received.
Unfortunately, MCU firmware quality varies widely, and some vendors even print debug information over UART in production models… 🤨

Depending on the device, a stray `ok` reply may drop the MCU into bootloader mode, essentially bricking the entire thing. 🧱

As long as a device has passed MIoT testing/validation, this change should improve compatibility substantially.

Fixes #60