### PR TITLE
xiaomi.feeder.iv2001: document as incompatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Xiaomi Air Purifier 4 Lite (CN Model) | zhimi.airp.rma3 | No dedicated MCU | [li
 Xiaomi Smart Air Purifier 4 Compact | zhimi.airp.cpa4 | No dedicated MCU | [link](../../issues/22#issuecomment-2137163103)|[link](https://home.miot-spec.com/spec/zhimi.airp.cpa4)
 Smartmi Evaporative Humidifier| zhimi.humidifier.cb1 | Proprietary chip | [link](../../issues/26#issuecomment-2417148320)|[link](https://home.miot-spec.com/spec/zhimi.humidifier.cb1)
 Xiaomi Smart Tower Fan | dmaker.fan.p39 | Proprietary chip | [link](../../pull/52) |[link](https://home.miot-spec.com/spec/dmaker.fan.p39)
+Xiaomi Smart Pet Food Feeder 2 | xiaomi.feeder.iv2001 | Proprietary chip | [link](../../pull/72)| [link](https://home.miot-spec.com/spec/xiaomi.feeder.iv2001)
 
 ## Building a firmware
 


### PR DESCRIPTION
The Xiaomi Smart Pet Food Feeder 2 international version (`xiaomi.feeder.iv2001`) uses the proprietary `MHCW05P-B` wifi module so... bummer.

It also appears to be the only MCU on the board, if there isn't one hiding under the LCD module.

![feeder](https://github.com/user-attachments/assets/043d19c4-0905-4fb3-83aa-dcbad2235e21)
