### PR TITLE
Add `dmaker.fan.p33.yaml`

### DIFF
--- a/config/dmaker.fan.p33.yaml
+++ b/config/dmaker.fan.p33.yaml
@@ -1,0 +1,155 @@
+# https://home.miot-spec.com/spec/dmaker.fan.p33
+
+external_components:
+  source: github://dhewg/esphome-miot@main
+
+esphome:
+  name: standing-fan-pro
+  friendly_name: Smart Standing Fan 2 Pro
+  comment: Xiaomi Mi Smart Standing Fan 2 (dmaker.fan.p33)
+  project:
+    name: "dhewg.esphome-miot"
+    version: "dmaker.fan.p33"
+
+esp8266:
+  board: esp_wroom_02
+
+logger:
+  level: DEBUG
+  # Important: Disable UART1 logging to avoid hardware errors on main UART0
+  baud_rate: 0
+
+api:
+  encryption:
+    key: !secret api_encryption_key
+  reboot_timeout: 0s
+  services:
+    - service: mcu_command
+      variables:
+        command: string
+      then:
+        - lambda: 'id(miot_main).queue_command(command);'
+
+ota:
+  - platform: esphome
+    password: !secret ota_password
+
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  ap:
+    password: !secret wifi_ap_password
+
+captive_portal:
+
+uart:
+  tx_pin: GPIO15
+  rx_pin: GPIO13
+  baud_rate: 115200
+
+miot:
+  id: miot_main
+
+fan:
+  - platform: "miot"
+    name: "Fan"
+    state:
+      miot_siid: 2
+      miot_piid: 1
+    speed:
+      miot_siid: 2
+      miot_piid: 6
+      min_value: 1
+      max_value: 100
+    oscillating:
+      miot_siid: 2
+      miot_piid: 4
+
+switch:
+  - platform: "miot"
+    miot_siid: 4
+    miot_piid: 1
+    name: "Indicator Lights"
+    icon: "mdi:lightbulb"
+    entity_category: config
+  - platform: "miot"
+    miot_siid: 5
+    miot_piid: 1
+    name: "Notification Sounds"
+    icon: "mdi:volume-high"
+    entity_category: config
+  - platform: "miot"
+    miot_siid: 7
+    miot_piid: 1
+    name: "Child Lock"
+    icon: "mdi:lock"
+    entity_category: config
+
+select:
+  - platform: "miot"
+    id: "mode"
+    miot_siid: 2
+    miot_piid: 3
+    name: "Mode"
+    icon: "mdi:leaf"
+    options:
+      0: "Direct Breeze"
+      1: "Natural Breeze"
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 5
+    name: "Oscillation Angle"
+    icon: "mdi:angle-obtuse"
+    options:
+      30: "30°"
+      60: "60°"
+      90: "90°"
+      120: "120°"
+      140: "140°"
+
+number:
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 2
+    name: "Fan Level"
+    icon: "mdi:fan-chevron-up"
+    min_value: 1
+    max_value: 4
+    step: 1
+  - platform: "miot"
+    miot_siid: 3
+    miot_piid: 1
+    name: "Off Delay"
+    icon: "mdi:clock-outline"
+    unit_of_measurement: "min"
+    device_class: duration
+    min_value: 0
+    max_value: 480
+    step: 1
+
+button:
+  - platform: "miot"
+    miot_siid: 2
+    miot_aiid: 1
+    name: "Toggle Power"
+    icon: "mdi:power-cycle"
+  - platform: "template"
+    name: "Adjust Left"
+    icon: "mdi:pan-left"
+    on_press:
+      - lambda: id(miot_main).queue_command("set_properties 6 1 1");
+  - platform: "template"
+    name: "Adjust Right"
+    icon: "mdi:pan-right"
+    on_press: 
+      - lambda: id(miot_main).queue_command("set_properties 6 1 2");
+  - platform: "miot"
+    name: "Toggle Mode"
+    icon: "mdi:leaf"
+    miot_siid: 3
+    miot_aiid: 1
+  - platform: "miot"
+    name: "Toggle Speed"
+    icon: "mdi:fan"
+    miot_siid: 3
+    miot_aiid: 2


### PR DESCRIPTION
Feature set is exactly the same as `dmaker.fan.p18`, but with some properties shuffled around.
Unfortunately, no battery status is supported…