### PR TITLE
Reply with `error` to invalid upstream data

### DIFF
--- a/components/miot/miot.cpp
+++ b/components/miot/miot.cpp
@@ -456,10 +456,10 @@ void Miot::process_message_() {
     send_reply_("ok");
     global_preferences->reset();
     App.safe_reboot();
-  } else if (std::strncmp(cmd.c_str(), "***", 3) == 0) {
+  } else if (cmd.size() < 3 || !std::islower(cmd[0]) || !std::islower(cmd[1]) || !std::islower(cmd[2])) {
     // Required for deerma.humidifier.jsq5 and other devices with picky MCUs
     // that enforce MIoT spec compliance, and print e.g. debug info over UART.
-    mcu_log("Invalid upstream data '%s'", get_printable_rx_message().c_str());
+    mcu_log("Invalid command '%s'", get_printable_rx_message().c_str());
     send_reply_("error");
   } else {
     mcu_log("Unknown command '%s'", get_printable_rx_message().c_str());

--- a/components/miot/miot.cpp
+++ b/components/miot/miot.cpp
@@ -456,6 +456,9 @@ void Miot::process_message_() {
     send_reply_("ok");
     global_preferences->reset();
     App.safe_reboot();
+  } else if (std::strncmp(cmd.c_str(), "***", 3) == 0) {
+    ESP_LOGI(TAG, "Ignoring MCU debug message '%s %s'", cmd.c_str(), saveptr);
+    send_reply_("error");
   } else {
     mcu_log("Unknown command '%s'", get_printable_rx_message().c_str());
     send_reply_("ok");

--- a/components/miot/miot.cpp
+++ b/components/miot/miot.cpp
@@ -26,7 +26,7 @@
  * TODO
  * add "access" to components? read/write/notify
  * automations?
- * reboot mcu on ota reboot
+ * ~~reboot mcu on ota reboot~~ Not possible.
  */
 
 namespace esphome {
@@ -457,10 +457,14 @@ void Miot::process_message_() {
     global_preferences->reset();
     App.safe_reboot();
   } else if (std::strncmp(cmd.c_str(), "***", 3) == 0) {
-    ESP_LOGI(TAG, "Ignoring MCU debug message '%s %s'", cmd.c_str(), saveptr);
+    // Required for deerma.humidifier.jsq5 and other devices with picky MCUs
+    // that enforce MIoT spec compliance, and print e.g. debug info over UART.
+    mcu_log("Invalid upstream data '%s'", get_printable_rx_message().c_str());
     send_reply_("error");
   } else {
     mcu_log("Unknown command '%s'", get_printable_rx_message().c_str());
+    // Technically, 'error' would be the correct default reply according to MIoT spec,
+    // but we are keeping 'ok' for now. Otherwise, an additional (~5) downstream commands need to be implemented.
     send_reply_("ok");
   }
 }


### PR DESCRIPTION
Fixes #66 & #69 by adding the missing `error` reply on invalid data.

Required for #71, otherwise we‘ll have a bunch of soft-bricked humidifiers.