### PR TITLE
Make the intervall of the sensor fan configurable and the poll timer of properties.

### DIFF
--- a/components/miot/__init__.py
+++ b/components/miot/__init__.py
@@ -9,7 +9,7 @@ miot_ns = cg.esphome_ns.namespace("miot")
 Miot = miot_ns.class_("Miot", cg.Component, uart.UARTDevice)
 
 CONF_MIOT_ID = "miot_id"
-CONF_MIOT_POLL_INTERVAL = "miot_poll_interval"    
+CONF_MIOT_POLL_INTERVAL = "miot_poll_interval"
 CONF_MIOT_HEARTBEAT_SIID = "miot_heartbeat_siid"
 CONF_MIOT_HEARTBEAT_PIID = "miot_heartbeat_piid"
 CONF_MIOT_HEARTBEAT_VALUE = "miot_heartbeat_value"

--- a/components/miot/__init__.py
+++ b/components/miot/__init__.py
@@ -54,7 +54,7 @@ async def to_code(config):
         cg.add(var.set_heartbeat_config(config[CONF_MIOT_HEARTBEAT_SIID], config[CONF_MIOT_HEARTBEAT_PIID]))
     cg.add(var.set_heartbeat_value(config[CONF_MIOT_HEARTBEAT_VALUE]))
     cg.add(var.set_heartbeat_interval(config[CONF_MIOT_HEARTBEAT_INTERVAL]))
-    cg.add(var.set_poll_interval(config[CONF_MIOT_POLL_INTERVAL]))    
+    cg.add(var.set_poll_interval(config[CONF_MIOT_POLL_INTERVAL]))
     cg.add(var.set_ota_net_indicator(config[CONF_MIOT_OTA_NET_INDICATOR]))
 
     cg.add_define("USE_OTA_STATE_CALLBACK")

--- a/components/miot/__init__.py
+++ b/components/miot/__init__.py
@@ -9,8 +9,11 @@ miot_ns = cg.esphome_ns.namespace("miot")
 Miot = miot_ns.class_("Miot", cg.Component, uart.UARTDevice)
 
 CONF_MIOT_ID = "miot_id"
+CONF_MIOT_POLL_INTERVAL = "miot_poll_interval"    
 CONF_MIOT_HEARTBEAT_SIID = "miot_heartbeat_siid"
 CONF_MIOT_HEARTBEAT_PIID = "miot_heartbeat_piid"
+CONF_MIOT_HEARTBEAT_VALUE = "miot_heartbeat_value"
+CONF_MIOT_HEARTBEAT_INTERVAL = "miot_heartbeat_interval"
 CONF_MIOT_OTA_NET_INDICATOR = "miot_ota_net_indicator"
 CONF_MIOT_SIID = "miot_siid"
 CONF_MIOT_PIID = "miot_piid"
@@ -30,8 +33,11 @@ CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(Miot),
+            cv.Optional(CONF_MIOT_POLL_INTERVAL, default=60000): cv.uint32_t, 
             cv.Optional(CONF_MIOT_HEARTBEAT_SIID): cv.uint32_t,
             cv.Optional(CONF_MIOT_HEARTBEAT_PIID): cv.uint32_t,
+            cv.Optional(CONF_MIOT_HEARTBEAT_VALUE, default=60): cv.uint32_t,
+            cv.Optional(CONF_MIOT_HEARTBEAT_INTERVAL, default=60000): cv.uint32_t,
             cv.Optional(CONF_MIOT_OTA_NET_INDICATOR, default="updating"): cv.string,
         }
     )
@@ -46,6 +52,9 @@ async def to_code(config):
     await uart.register_uart_device(var, config)
     if (CONF_MIOT_HEARTBEAT_SIID in config) and (CONF_MIOT_HEARTBEAT_PIID in config):
         cg.add(var.set_heartbeat_config(config[CONF_MIOT_HEARTBEAT_SIID], config[CONF_MIOT_HEARTBEAT_PIID]))
+    cg.add(var.set_heartbeat_value(config[CONF_MIOT_HEARTBEAT_VALUE]))
+    cg.add(var.set_heartbeat_interval(config[CONF_MIOT_HEARTBEAT_INTERVAL]))
+    cg.add(var.set_poll_interval(config[CONF_MIOT_POLL_INTERVAL]))    
     cg.add(var.set_ota_net_indicator(config[CONF_MIOT_OTA_NET_INDICATOR]))
 
     cg.add_define("USE_OTA_STATE_CALLBACK")

--- a/components/miot/__init__.py
+++ b/components/miot/__init__.py
@@ -52,8 +52,8 @@ async def to_code(config):
     await uart.register_uart_device(var, config)
     if (CONF_MIOT_HEARTBEAT_SIID in config) and (CONF_MIOT_HEARTBEAT_PIID in config):
         cg.add(var.set_heartbeat_config(config[CONF_MIOT_HEARTBEAT_SIID], config[CONF_MIOT_HEARTBEAT_PIID]))
-    cg.add(var.set_heartbeat_value(config[CONF_MIOT_HEARTBEAT_VALUE]))
-    cg.add(var.set_heartbeat_interval(config[CONF_MIOT_HEARTBEAT_INTERVAL]))
+        cg.add(var.set_heartbeat_value(config[CONF_MIOT_HEARTBEAT_VALUE]))
+        cg.add(var.set_heartbeat_interval(config[CONF_MIOT_HEARTBEAT_INTERVAL]))
     cg.add(var.set_poll_interval(config[CONF_MIOT_POLL_INTERVAL]))
     cg.add(var.set_ota_net_indicator(config[CONF_MIOT_OTA_NET_INDICATOR]))
 

--- a/components/miot/__init__.py
+++ b/components/miot/__init__.py
@@ -33,7 +33,7 @@ CONFIG_SCHEMA = cv.All(
     cv.Schema(
         {
             cv.GenerateID(): cv.declare_id(Miot),
-            cv.Optional(CONF_MIOT_POLL_INTERVAL, default=60000): cv.uint32_t, 
+            cv.Optional(CONF_MIOT_POLL_INTERVAL, default=60000): cv.uint32_t,
             cv.Optional(CONF_MIOT_HEARTBEAT_SIID): cv.uint32_t,
             cv.Optional(CONF_MIOT_HEARTBEAT_PIID): cv.uint32_t,
             cv.Optional(CONF_MIOT_HEARTBEAT_VALUE, default=60): cv.uint32_t,

--- a/components/miot/miot.cpp
+++ b/components/miot/miot.cpp
@@ -62,7 +62,7 @@ void Miot::setup() {
 
   queue_command("MIIO_mcu_version_req");
 
-  this->set_interval("poll", 60000, [this] {
+  this->set_interval("poll", poll_interval_, [this] {
     std::string cmd, part;
     cmd.reserve(MAX_LINE_LENGTH);
     part.reserve(MAX_COMMAND_LENGTH);
@@ -85,8 +85,8 @@ void Miot::setup() {
   });
 
   if (heartbeat_siid_ != 0 && heartbeat_piid_ != 0)
-    this->set_interval("heartbeat", 60000, [this] {
-      set_property(heartbeat_siid_, heartbeat_piid_, MiotValue(60));
+    this->set_interval("heartbeat", heartbeat_interval_, [this] {
+      set_property(heartbeat_siid_, heartbeat_piid_, MiotValue(heartbeat_value_));
     });
 
 #ifdef USE_OTA

--- a/components/miot/miot.cpp
+++ b/components/miot/miot.cpp
@@ -208,6 +208,12 @@ void Miot::queue_command(const char *fmt, ...) {
   queue_command(cmd);
 }
 
+void Miot::set_heartbeat_interval(uint32_t interval) {
+  // Delegate to the runtime-rescheduling method so scripts using
+  // set_heartbeat_interval() immediately take effect
+  update_heartbeat_interval(interval);
+}
+
 void Miot::update_poll_interval(uint32_t interval) {
   if (this->poll_interval_ == interval)
     return;

--- a/components/miot/miot.h
+++ b/components/miot/miot.h
@@ -80,6 +80,11 @@ class Miot : public Component, public uart::UARTDevice {
   void set_heartbeat_interval(uint32_t interval) {
     this->heartbeat_interval_ = interval;
   };
+  void update_poll_interval(uint32_t interval);
+  void update_heartbeat_interval(uint32_t interval);
+  void update_heartbeat_value(uint32_t value) {
+    this->heartbeat_value_ = value;
+  };
   void register_listener(uint32_t siid, uint32_t piid, bool poll, MiotValueType type, const std::function<void(const MiotValue &value)> &func);
   void queue_command(const std::string &cmd);
   void queue_command(const char *fmt, ...) __attribute__((format(printf, 2, 3)));

--- a/components/miot/miot.h
+++ b/components/miot/miot.h
@@ -77,9 +77,7 @@ class Miot : public Component, public uart::UARTDevice {
   void set_ota_net_indicator(const std::string &indicator) {
     this->ota_net_indicator_ = indicator;
   };
-  void set_heartbeat_interval(uint32_t interval) {
-    this->heartbeat_interval_ = interval;
-  };
+  void set_heartbeat_interval(uint32_t interval);
   void update_poll_interval(uint32_t interval);
   void update_heartbeat_interval(uint32_t interval);
   void update_heartbeat_value(uint32_t value) {

--- a/components/miot/miot.h
+++ b/components/miot/miot.h
@@ -82,7 +82,7 @@ class Miot : public Component, public uart::UARTDevice {
   };
   void register_listener(uint32_t siid, uint32_t piid, bool poll, MiotValueType type, const std::function<void(const MiotValue &value)> &func);
   void queue_command(const std::string &cmd);
-  void queue_command(const char *fmt, .. .) __attribute__((format(printf, 2, 3)));
+  void queue_command(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
   void queue_net_change_command(bool force);
   void set_property(uint32_t siid, uint32_t piid, const MiotValue &value);
   void execute_action(uint32_t siid, uint32_t aiid, const std::string &args);

--- a/components/miot/miot.h
+++ b/components/miot/miot.h
@@ -64,7 +64,7 @@ class Miot : public Component, public uart::UARTDevice {
   std::string get_printable_string(const uint8_t *data, size_t len);
   std::string get_printable_string(const std::string &str);
 
-  void set_poll_value(uint32_t interval) {
+  void set_poll_interval(uint32_t interval) {
     this->poll_interval_ = interval;
   };
   void set_heartbeat_config(uint32_t siid, uint32_t piid) {

--- a/components/miot/miot.h
+++ b/components/miot/miot.h
@@ -64,16 +64,25 @@ class Miot : public Component, public uart::UARTDevice {
   std::string get_printable_string(const uint8_t *data, size_t len);
   std::string get_printable_string(const std::string &str);
 
+  void set_poll_value(uint32_t interval) {
+    this->poll_interval_ = interval;
+  };
   void set_heartbeat_config(uint32_t siid, uint32_t piid) {
     this->heartbeat_siid_ = siid;
     this->heartbeat_piid_ = piid;
   };
+  void set_heartbeat_value(uint32_t value) {
+    this->heartbeat_value_ = value;
+  };
   void set_ota_net_indicator(const std::string &indicator) {
     this->ota_net_indicator_ = indicator;
   };
+  void set_heartbeat_interval(uint32_t interval) {
+    this->heartbeat_interval_ = interval;
+  };
   void register_listener(uint32_t siid, uint32_t piid, bool poll, MiotValueType type, const std::function<void(const MiotValue &value)> &func);
   void queue_command(const std::string &cmd);
-  void queue_command(const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+  void queue_command(const char *fmt, .. .) __attribute__((format(printf, 2, 3)));
   void queue_net_change_command(bool force);
   void set_property(uint32_t siid, uint32_t piid, const MiotValue &value);
   void execute_action(uint32_t siid, uint32_t aiid, const std::string &args);
@@ -106,8 +115,11 @@ class Miot : public Component, public uart::UARTDevice {
   std::deque<std::string> mcu_log_;
   std::queue<std::string> command_queue_;
   bool expect_action_result_{false};
+  uint32_t poll_interval_{60000};
   uint32_t heartbeat_siid_{0};
   uint32_t heartbeat_piid_{0};
+  uint32_t heartbeat_value_{60};
+  uint32_t heartbeat_interval_{60000};
   std::string ota_net_indicator_;
   std::map<std::pair<uint32_t, uint32_t>, MiotListener> listeners_;
 #ifdef USE_EVENT


### PR DESCRIPTION
I have my Xiaomi-Mi-Air-Purifier-3C in my bedroom and the fan of the sensor is quite loud and also the fan gets very fast bad when it is running 24/7 i know that because i have many of such little fans running for pi cluster as example.

So i make the intervall time in which is the sensor gets readed configurable and i saw that the poll rate of properties is also fix at 60s so i make that also in the same way configurable. with that code it should be possible to controll it like

```
miot:
  id:  miot_aqi
  miot_heartbeat_siid: 9
  miot_heartbeat_piid: 4
  miot_heartbeat_value:  10 
  miot_heartbeat_interval: 30000
```
  
  that should run the pm2.5 sensor for 10s every 30s as example.