### PR TITLE
Update zhimi.humidifier.ca4.yaml with the latest MIOT

### DIFF
--- a/config/zhimi.humidifier.ca4.yaml
+++ b/config/zhimi.humidifier.ca4.yaml
@@ -1,4 +1,5 @@
-# https://home.miot-spec.com/spec/zhimi.humidifier.ca4
+# MIoT spec: https://home.miot-spec.com/spec/zhimi.humidifier.ca4
+# Instance (v2): https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:humidifier:0000A00E:zhimi-ca4:2
 
 external_components:
   source: github://dhewg/esphome-miot@main
@@ -18,6 +19,7 @@ esp32:
     sdkconfig_options:
       CONFIG_FREERTOS_UNICORE: y
     advanced:
+      # Required on some devices due to EFUSE layout differences
       ignore_efuse_custom_mac: true
       ignore_efuse_mac_crc: true
 
@@ -52,8 +54,15 @@ uart:
   rx_pin: GPIO16
   baud_rate: 115200
 
+time:
+  - platform: homeassistant
+    id: ha_time
+    timezone: Europe/Amsterdam
+
 miot:
   id: miot_main
+
+# Controls (writable MIoT properties)
 
 fan:
   - platform: "miot"
@@ -73,18 +82,22 @@ switch:
     miot_piid: 8
     name: "Dry"
     icon: mdi:water-minus
+
+  # "Alarm" is the device buzzer / notification sounds in the official MIoT spec.
   - platform: "miot"
     miot_siid: 4
     miot_piid: 1
     name: "Notification Sounds"
     icon: mdi:volume-high
     entity_category: config
+
   - platform: "miot"
     miot_siid: 6
     miot_piid: 1
     name: "Child Lock"
     icon: mdi:lock
     entity_category: config
+
   - platform: "miot"
     miot_siid: 7
     miot_piid: 5
@@ -104,6 +117,23 @@ select:
       1: "Glimmer"
       2: "Brightest"
 
+  # Region setting used by the MCU (writable).
+  - platform: "miot"
+    miot_siid: 7
+    miot_piid: 4
+    name: "Country Code"
+    icon: mdi:earth
+    entity_category: config
+    options:
+      0: "Unknown"
+      1: "US"
+      7: "RU"
+      33: "FR"
+      44: "EU (Europe)"
+      81: "JP"
+      82: "KR"
+      86: "CN"
+
 number:
   - platform: "miot"
     miot_siid: 2
@@ -115,13 +145,16 @@ number:
     max_value: 80
     step: 1
 
+# Sensors (read-only MIoT properties)
+
 sensor:
   - platform: "miot"
     miot_siid: 2
     miot_piid: 2
     name: "Device Fault Code"
-    icon: mdi:fan-alert
+    icon: mdi:alert-circle-outline
     entity_category: diagnostic
+
   - platform: "miot"
     miot_siid: 3
     miot_piid: 7
@@ -130,6 +163,7 @@ sensor:
     device_class: temperature
     state_class: measurement
     icon: mdi:thermometer
+
   - platform: "miot"
     miot_siid: 3
     miot_piid: 9
@@ -138,29 +172,76 @@ sensor:
     device_class: humidity
     state_class: measurement
     icon: mdi:water-percent
+
   - platform: "miot"
     miot_siid: 2
     miot_piid: 7
     name: "Water Level"
     unit_of_measurement: "%"
     state_class: measurement
-    icon: mdi:water-percent
+    icon: mdi:cup-water
     filters:
       - clamp:
           min_value: 0
           max_value: 100
           ignore_out_of_range: true
+
+  # "Speed Level" is a writable setpoint (200..2000, step 10) in the MIoT spec.
   - platform: "miot"
     miot_siid: 2
     miot_piid: 11
-    name: "Motor Speed"
+    name: "Motor Speed Setpoint"
     unit_of_measurement: "rpm"
     icon: mdi:fan
+    entity_category: diagnostic
+
   - platform: "miot"
     miot_siid: 7
     miot_piid: 1
     name: "Actual Speed"
     unit_of_measurement: "rpm"
     icon: mdi:fan
+
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 9
+    name: "Total Use Time"
+    unit_of_measurement: "h"
+    icon: mdi:timer-outline
+    entity_category: diagnostic
+    state_class: total_increasing
+    filters:
+      - multiply: 0.0002777778
+
+  - platform: "miot"
+    miot_siid: 7
+    miot_piid: 3
+    name: "Power Time"
+    unit_of_measurement: "h"
+    icon: mdi:timer
+    entity_category: diagnostic
+    state_class: measurement
+    filters:
+      - multiply: 0.0002777778
+
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 10
+    name: "Last Button Pressed"
+    icon: mdi:gesture-tap-button
+    entity_category: diagnostic
+
   - platform: internal_temperature
     name: "MCU Temperature"
+    unit_of_measurement: "°C"
+    device_class: temperature
+    state_class: measurement
+
+  - platform: "miot"
+    miot_siid: 3
+    miot_piid: 8
+    name: "Temperature (F)"
+    unit_of_measurement: "°F"
+    device_class: temperature
+    state_class: measurement
+    entity_category: diagnostic

--- a/config/zhimi.humidifier.ca4.yaml
+++ b/config/zhimi.humidifier.ca4.yaml
@@ -1,4 +1,5 @@
-# https://home.miot-spec.com/spec/zhimi.humidifier.ca4
+# MIoT spec: https://home.miot-spec.com/spec/zhimi.humidifier.ca4
+# Instance (v2): https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:humidifier:0000A00E:zhimi-ca4:2
 
 external_components:
   source: github://dhewg/esphome-miot@main
@@ -18,6 +19,7 @@ esp32:
     sdkconfig_options:
       CONFIG_FREERTOS_UNICORE: y
     advanced:
+      # Required on some devices due to EFUSE layout differences
       ignore_efuse_custom_mac: true
       ignore_efuse_mac_crc: true
 
@@ -25,8 +27,6 @@ logger:
   level: INFO
 
 api:
-  encryption:
-    key: !secret api_encryption_key
   reboot_timeout: 0s
   services:
     - service: mcu_command
@@ -37,13 +37,13 @@ api:
 
 ota:
   - platform: esphome
-    password: !secret ota_password
 
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
   ap:
-    password: !secret wifi_ap_password
+    ssid: "Humidifier Fallback"
+    password: !secret wifi_password
 
 captive_portal:
 
@@ -52,39 +52,44 @@ uart:
   rx_pin: GPIO16
   baud_rate: 115200
 
+time:
+  - platform: homeassistant
+    id: ha_time
+    timezone: Europe/Amsterdam
+
 miot:
   id: miot_main
 
-fan:
-  - platform: "miot"
-    name: "Fan"
-    state:
-      miot_siid: 2
-      miot_piid: 1
-    speed:
-      miot_siid: 2
-      miot_piid: 5
-      min_value: 0
-      max_value: 3
+# Controls (writeable MIoT properties)
 
 switch:
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 1
+    name: "Power"
+    icon: mdi:power
+
   - platform: "miot"
     miot_siid: 2
     miot_piid: 8
     name: "Dry"
     icon: mdi:water-minus
+
+  # "Alarm" is the device buzzer / notification sounds in the official MIoT spec.
   - platform: "miot"
     miot_siid: 4
     miot_piid: 1
     name: "Notification Sounds"
     icon: mdi:volume-high
     entity_category: config
+
   - platform: "miot"
     miot_siid: 6
     miot_piid: 1
     name: "Child Lock"
     icon: mdi:lock
     entity_category: config
+
   - platform: "miot"
     miot_siid: 7
     miot_piid: 5
@@ -94,9 +99,40 @@ switch:
 
 select:
   - platform: "miot"
+    miot_siid: 2
+    miot_piid: 5
+    name: "Fan Level"
+    icon: mdi:fan
+    options:
+      0: "Auto"
+      1: "Low"
+      2: "Medium"
+      3: "High"
+
+  # Target humidity is a 30..80% range in the MIoT spec.
+  # Using a select keeps it compatible even if your esphome-miot build does not expose a number platform.
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 6
+    name: "Target Humidity"
+    icon: mdi:water-percent
+    options:
+      30: "30%"
+      35: "35%"
+      40: "40%"
+      45: "45%"
+      50: "50%"
+      55: "55%"
+      60: "60%"
+      65: "65%"
+      70: "70%"
+      75: "75%"
+      80: "80%"
+
+  - platform: "miot"
     miot_siid: 5
     miot_piid: 2
-    name: "Display brightness"
+    name: "Display Brightness"
     icon: mdi:brightness-6
     entity_category: config
     options:
@@ -104,52 +140,120 @@ select:
       1: "Glimmer"
       2: "Brightest"
 
+  # Region setting used by the MCU (writeable).
+  - platform: "miot"
+    miot_siid: 7
+    miot_piid: 4
+    name: "Country Code"
+    icon: mdi:earth
+    entity_category: config
+    options:
+      0: "Unknown"
+      1: "US"
+      7: "RU"
+      33: "FR"
+      44: "EU (Europe)"
+      81: "JP"
+      82: "KR"
+      86: "CN"
+
+# Sensors (read-only MIoT properties)
+
 sensor:
   - platform: "miot"
     miot_siid: 2
     miot_piid: 2
     name: "Device Fault Code"
-    icon: mdi:fan-alert
+    icon: mdi:alert-circle-outline
     entity_category: diagnostic
+
   - platform: "miot"
     miot_siid: 3
     miot_piid: 7
     name: "Temperature"
     unit_of_measurement: "°C"
     device_class: temperature
-    state_class: "measurement"
+    state_class: measurement
     icon: mdi:thermometer
+
   - platform: "miot"
     miot_siid: 3
     miot_piid: 9
     name: "Relative Humidity"
     unit_of_measurement: "%"
     device_class: humidity
-    state_class: "measurement"
+    state_class: measurement
     icon: mdi:water-percent
+
   - platform: "miot"
     miot_siid: 2
     miot_piid: 7
     name: "Water Level"
     unit_of_measurement: "%"
-    state_class: "measurement"
-    icon: mdi:water-percent
+    state_class: measurement
+    icon: mdi:cup-water
     filters:
       - clamp:
           min_value: 0
           max_value: 100
           ignore_out_of_range: true
+
+  # "Speed Level" is a writeable setpoint (200..2000, step 10) in the MIoT spec.
   - platform: "miot"
     miot_siid: 2
     miot_piid: 11
-    name: "Motor Speed"
+    name: "Motor Speed Setpoint"
     unit_of_measurement: "rpm"
     icon: mdi:fan
+    entity_category: diagnostic
+
   - platform: "miot"
     miot_siid: 7
     miot_piid: 1
     name: "Actual Speed"
     unit_of_measurement: "rpm"
     icon: mdi:fan
+
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 9
+    name: "Total Use Time"
+    unit_of_measurement: "h"
+    icon: mdi:timer-outline
+    entity_category: diagnostic
+    state_class: total_increasing
+    filters:
+      - multiply: 0.0002777778
+
+  - platform: "miot"
+    miot_siid: 7
+    miot_piid: 3
+    name: "Power Time"
+    unit_of_measurement: "h"
+    icon: mdi:timer
+    entity_category: diagnostic
+    state_class: measurement
+    filters:
+      - multiply: 0.0002777778
+
+  - platform: "miot"
+    miot_siid: 2
+    miot_piid: 10
+    name: "Last Button Pressed"
+    icon: mdi:gesture-tap-button
+    entity_category: diagnostic
+
   - platform: internal_temperature
     name: "MCU Temperature"
+    unit_of_measurement: "°C"
+    device_class: temperature
+    state_class: measurement
+
+  - platform: "miot"
+    miot_siid: 3
+    miot_piid: 8
+    name: "Temperature (F)"
+    unit_of_measurement: "°F"
+    device_class: temperature
+    state_class: measurement
+    entity_category: diagnostic

--- a/config/zhimi.humidifier.ca4.yaml
+++ b/config/zhimi.humidifier.ca4.yaml
@@ -1,5 +1,4 @@
-# MIoT spec: https://home.miot-spec.com/spec/zhimi.humidifier.ca4
-# Instance (v2): https://miot-spec.org/miot-spec-v2/instance?type=urn:miot-spec-v2:device:humidifier:0000A00E:zhimi-ca4:2
+# https://home.miot-spec.com/spec/zhimi.humidifier.ca4
 
 external_components:
   source: github://dhewg/esphome-miot@main
@@ -19,7 +18,6 @@ esp32:
     sdkconfig_options:
       CONFIG_FREERTOS_UNICORE: y
     advanced:
-      # Required on some devices due to EFUSE layout differences
       ignore_efuse_custom_mac: true
       ignore_efuse_mac_crc: true
 
@@ -27,23 +25,25 @@ logger:
   level: INFO
 
 api:
+  encryption:
+    key: !secret api_encryption_key
   reboot_timeout: 0s
   services:
     - service: mcu_command
       variables:
         command: string
       then:
-        - lambda: 'id(miot_main).queue_command(command);'
+        - lambda: "id(miot_main).queue_command(command);"
 
 ota:
   - platform: esphome
+    password: !secret ota_password
 
 wifi:
   ssid: !secret wifi_ssid
   password: !secret wifi_password
   ap:
-    ssid: "Humidifier Fallback"
-    password: !secret wifi_password
+    password: !secret wifi_ap_password
 
 captive_portal:
 
@@ -52,44 +52,39 @@ uart:
   rx_pin: GPIO16
   baud_rate: 115200
 
-time:
-  - platform: homeassistant
-    id: ha_time
-    timezone: Europe/Amsterdam
-
 miot:
   id: miot_main
 
-# Controls (writeable MIoT properties)
+fan:
+  - platform: "miot"
+    name: "Fan"
+    state:
+      miot_siid: 2
+      miot_piid: 1
+    speed:
+      miot_siid: 2
+      miot_piid: 5
+      min_value: 0
+      max_value: 3
 
 switch:
-  - platform: "miot"
-    miot_siid: 2
-    miot_piid: 1
-    name: "Power"
-    icon: mdi:power
-
   - platform: "miot"
     miot_siid: 2
     miot_piid: 8
     name: "Dry"
     icon: mdi:water-minus
-
-  # "Alarm" is the device buzzer / notification sounds in the official MIoT spec.
   - platform: "miot"
     miot_siid: 4
     miot_piid: 1
     name: "Notification Sounds"
     icon: mdi:volume-high
     entity_category: config
-
   - platform: "miot"
     miot_siid: 6
     miot_piid: 1
     name: "Child Lock"
     icon: mdi:lock
     entity_category: config
-
   - platform: "miot"
     miot_siid: 7
     miot_piid: 5
@@ -98,37 +93,6 @@ switch:
     entity_category: config
 
 select:
-  - platform: "miot"
-    miot_siid: 2
-    miot_piid: 5
-    name: "Fan Level"
-    icon: mdi:fan
-    options:
-      0: "Auto"
-      1: "Low"
-      2: "Medium"
-      3: "High"
-
-  # Target humidity is a 30..80% range in the MIoT spec.
-  # Using a select keeps it compatible even if your esphome-miot build does not expose a number platform.
-  - platform: "miot"
-    miot_siid: 2
-    miot_piid: 6
-    name: "Target Humidity"
-    icon: mdi:water-percent
-    options:
-      30: "30%"
-      35: "35%"
-      40: "40%"
-      45: "45%"
-      50: "50%"
-      55: "55%"
-      60: "60%"
-      65: "65%"
-      70: "70%"
-      75: "75%"
-      80: "80%"
-
   - platform: "miot"
     miot_siid: 5
     miot_piid: 2
@@ -140,33 +104,24 @@ select:
       1: "Glimmer"
       2: "Brightest"
 
-  # Region setting used by the MCU (writeable).
+number:
   - platform: "miot"
-    miot_siid: 7
-    miot_piid: 4
-    name: "Country Code"
-    icon: mdi:earth
-    entity_category: config
-    options:
-      0: "Unknown"
-      1: "US"
-      7: "RU"
-      33: "FR"
-      44: "EU (Europe)"
-      81: "JP"
-      82: "KR"
-      86: "CN"
-
-# Sensors (read-only MIoT properties)
+    miot_siid: 2
+    miot_piid: 6
+    name: "Target Humidity"
+    icon: mdi:water-percent
+    unit_of_measurement: "%"
+    min_value: 30
+    max_value: 80
+    step: 1
 
 sensor:
   - platform: "miot"
     miot_siid: 2
     miot_piid: 2
     name: "Device Fault Code"
-    icon: mdi:alert-circle-outline
+    icon: mdi:fan-alert
     entity_category: diagnostic
-
   - platform: "miot"
     miot_siid: 3
     miot_piid: 7
@@ -175,7 +130,6 @@ sensor:
     device_class: temperature
     state_class: measurement
     icon: mdi:thermometer
-
   - platform: "miot"
     miot_siid: 3
     miot_piid: 9
@@ -184,76 +138,29 @@ sensor:
     device_class: humidity
     state_class: measurement
     icon: mdi:water-percent
-
   - platform: "miot"
     miot_siid: 2
     miot_piid: 7
     name: "Water Level"
     unit_of_measurement: "%"
     state_class: measurement
-    icon: mdi:cup-water
+    icon: mdi:water-percent
     filters:
       - clamp:
           min_value: 0
           max_value: 100
           ignore_out_of_range: true
-
-  # "Speed Level" is a writeable setpoint (200..2000, step 10) in the MIoT spec.
   - platform: "miot"
     miot_siid: 2
     miot_piid: 11
-    name: "Motor Speed Setpoint"
+    name: "Motor Speed"
     unit_of_measurement: "rpm"
     icon: mdi:fan
-    entity_category: diagnostic
-
   - platform: "miot"
     miot_siid: 7
     miot_piid: 1
     name: "Actual Speed"
     unit_of_measurement: "rpm"
     icon: mdi:fan
-
-  - platform: "miot"
-    miot_siid: 2
-    miot_piid: 9
-    name: "Total Use Time"
-    unit_of_measurement: "h"
-    icon: mdi:timer-outline
-    entity_category: diagnostic
-    state_class: total_increasing
-    filters:
-      - multiply: 0.0002777778
-
-  - platform: "miot"
-    miot_siid: 7
-    miot_piid: 3
-    name: "Power Time"
-    unit_of_measurement: "h"
-    icon: mdi:timer
-    entity_category: diagnostic
-    state_class: measurement
-    filters:
-      - multiply: 0.0002777778
-
-  - platform: "miot"
-    miot_siid: 2
-    miot_piid: 10
-    name: "Last Button Pressed"
-    icon: mdi:gesture-tap-button
-    entity_category: diagnostic
-
   - platform: internal_temperature
     name: "MCU Temperature"
-    unit_of_measurement: "°C"
-    device_class: temperature
-    state_class: measurement
-
-  - platform: "miot"
-    miot_siid: 3
-    miot_piid: 8
-    name: "Temperature (F)"
-    unit_of_measurement: "°F"
-    device_class: temperature
-    state_class: measurement
-    entity_category: diagnostic


### PR DESCRIPTION
## Summary
Updates the `zhimi.humidifier.ca4` example configuration to better match the current MIoT spec and expose more of the device’s capabilities as standard ESPHome entities.

## What changed
- Added a native `fan:` entity backed by MIoT power (SIID 2 / PIID 1) and fan level (SIID 2 / PIID 5), with 0..3 speed range.
- Expanded/normalized controls and naming:
  - Standardized entity names (e.g. “Display Brightness”).
  - Added/updated “Country Code” select (SIID 7 / PIID 4) with explicit region options.
- Expanded sensors and cleanup:
  - Fixed icons and `state_class` formatting.
  - Added/kept diagnostic sensors like total use time, power time, last button pressed, MCU temperature, and Fahrenheit temperature.
  - Water level clamped to 0..100%.
- Added placeholders for common best practices: API encryption key, OTA password, and a dedicated WiFi AP password secret.

## How to test
1. Flash with this updated example config.
2. Verify entities show up in HA:
   - Fan can turn on/off and adjust speed.
   - Water level, temperature, humidity update correctly.
   - Country Code and Display Brightness can be set without errors.