### PR TITLE
fan: support named modes without exposing speed

### DIFF
--- a/components/miot/fan/__init__.py
+++ b/components/miot/fan/__init__.py
@@ -23,6 +23,7 @@ from .. import (
 DEPENDENCIES = ["miot"]
 
 MiotFan = miot_ns.class_("MiotFan", cg.Component, fan.Fan)
+CONF_EXPOSE_SPEED = "expose_speed"
 
 def ensure_option_map(value):
     cv.check_not_templatable(value)
@@ -58,6 +59,7 @@ CONFIG_SCHEMA = cv.All(
                     cv.Optional(CONF_STEP, default=1): cv.uint32_t,
                 }
             ),
+            cv.Optional(CONF_EXPOSE_SPEED, default=True): cv.boolean,
             cv.Optional(CONF_OSCILLATING): cv.Schema(
                 {
                     cv.Required(CONF_MIOT_SIID): cv.uint32_t,
@@ -91,6 +93,7 @@ async def to_code(config):
     cg.add(var.set_state_config(state[CONF_MIOT_SIID], state[CONF_MIOT_PIID]))
     speed = config.get(CONF_SPEED)
     cg.add(var.set_speed_config(speed[CONF_MIOT_SIID], speed[CONF_MIOT_PIID], speed[CONF_MIN_VALUE], speed[CONF_MAX_VALUE], speed[CONF_STEP]))
+    cg.add(var.set_expose_speed(config[CONF_EXPOSE_SPEED]))
     if oscillating := config.get(CONF_OSCILLATING):
         cg.add(var.set_oscillating_config(oscillating[CONF_MIOT_SIID], oscillating[CONF_MIOT_PIID]))
     if direction := config.get(CONF_DIRECTION):

--- a/components/miot/fan/miot_fan.h
+++ b/components/miot/fan/miot_fan.h
@@ -23,6 +23,7 @@ class MiotFan : public Component, public fan::Fan {
     this->speed_max_ = max;
     this->speed_step_ = step;
   }
+  void set_expose_speed(bool expose_speed) { this->expose_speed_ = expose_speed; }
   void set_oscillating_config(uint32_t siid, uint32_t piid) {
     this->oscillating_siid_ = siid;
     this->oscillating_piid_ = piid;
@@ -52,6 +53,7 @@ class MiotFan : public Component, public fan::Fan {
   uint32_t state_piid_{0};
   uint32_t speed_siid_{0};
   uint32_t speed_piid_{0};
+  bool expose_speed_{true};
   uint32_t speed_min_{0}, speed_max_{0}, speed_step_{0};
   uint32_t oscillating_siid_{0};
   uint32_t oscillating_piid_{0};

--- a/config/zhimi.humidifier.ca4.yaml
+++ b/config/zhimi.humidifier.ca4.yaml
@@ -66,6 +66,15 @@ fan:
       miot_piid: 5
       min_value: 0
       max_value: 3
+    expose_speed: false
+    preset_modes:
+      miot_siid: 2
+      miot_piid: 5
+      options:
+        0: "Auto"
+        1: "Low"
+        2: "Medium"
+        3: "High"
 
 switch:
   - platform: "miot"


### PR DESCRIPTION
## Summary
- add `fan.expose_speed` option to `miot` fan (default: `true`)
- allow hiding percentage speed UI while still using fan preset modes
- update `zhimi.humidifier.ca4` example to expose `Auto/Low/Medium/High` as preset modes on `2:5`

## Why
Some devices expose fixed mode levels that are clearer as named modes than percentages.

## Scope
- based on `main`
- only includes the named-mode/speed-visibility change
