### PR TITLE
switch: support restore_mode

### DIFF
--- a/components/miot/switch/__init__.py
+++ b/components/miot/switch/__init__.py
@@ -19,7 +19,7 @@ DEPENDENCIES = ["miot"]
 MiotSwitch = miot_ns.class_("MiotSwitch", switch.Switch, cg.Component)
 
 CONFIG_SCHEMA = (
-    switch.switch_schema(MiotSwitch)
+    switch.switch_schema(MiotSwitch, default_restore_mode="DISABLED")
     .extend(
         {
             cv.GenerateID(CONF_MIOT_ID): cv.use_id(Miot),

--- a/components/miot/switch/miot_switch.cpp
+++ b/components/miot/switch/miot_switch.cpp
@@ -7,9 +7,21 @@ namespace miot {
 static const char *const TAG = "miot.switch";
 
 void MiotSwitch::setup() {
+  this->restore_state_ = this->get_initial_state_with_restore_mode();
+  this->restore_pending_ = this->restore_state_.has_value();
+
   this->parent_->register_listener(this->siid_, this->piid_, this->poll_, mvtString, [this](const MiotValue &value) {
     bool v = value.as_string == true_value_;
     ESP_LOGV(TAG, "MCU reported switch %" PRIu32 ":%" PRIu32 " is: %s", this->siid_, this->piid_, ONOFF(v));
+
+    if (this->restore_pending_) {
+      this->restore_pending_ = false;
+      if (this->restore_state_.value() != v) {
+        this->write_state(this->restore_state_.value());
+        return;
+      }
+    }
+
     this->publish_state(v);
   });
 }

--- a/components/miot/switch/miot_switch.h
+++ b/components/miot/switch/miot_switch.h
@@ -33,6 +33,8 @@ class MiotSwitch : public switch_::Switch, public Component {
   bool poll_{true};
   std::string true_value_;
   std::string false_value_;
+  optional<bool> restore_state_{};
+  bool restore_pending_{false};
 };
 
 }  // namespace miot


### PR DESCRIPTION
Add `restore_mode` support to the MIoT `switch` platform via `switch.switch_schema(MiotSwitch, default_restore_mode="DISABLED")`. Opt-in, default DISABLED, so existing configs are unaffected.

Some MIoT devices don't persist power state across a power cut. For example, the Mi Smart Standing Fan 2 (dmaker.fan.p18) remembers Mode and Oscillation on its MCU but Power always comes back off, with no way to restore it.

`setup()` reads the restored value via `get_initial_state_with_restore_mode()`. On the first property report from the MCU after boot, if it differs from the restored value, we re-assert the restored state with `write_state()`; otherwise we just publish the reported value. After that, reports are handled as before, so the MCU stays the source of truth. Since this reacts to the first MCU report instead of polling, restore happens within ~1-2s of boot.

Tested on dmaker.fan.p18 (ESP8266) with `restore_mode: RESTORE_DEFAULT_OFF` on the Power switch. After a real power cut it comes back on within 1-2s. Configs without `restore_mode` set are unaffected.
