### PR TITLE
xiaomi.fan.p76: document as incompatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Smartmi Evaporative Humidifier | zhimi.humidifier.cb1 | Proprietary chip _MHCWB2
 Smartmi Evaporative Humidifier 3 | zhimi.humidifier.ca6 | No dedicated MCU | [link](../../issues/102) | [link](https://home.miot-spec.com/spec/zhimi.humidifier.ca6)
 Xiaomi Smart Tower Fan | dmaker.fan.p39 | Proprietary chip _MHCWB4P-B_ | [link](../../pull/52) | [link](https://home.miot-spec.com/spec/dmaker.fan.p39)
 Xiaomi Smart Tower Fan 2 | xiaomi.fan.p45 | Proprietary chip _MHCWB5G-B_ | [link](../../issues/78) | [link](https://home.miot-spec.com/spec/xiaomi.fan.p45)
+Xiaomi Smart Standing Air Circulation Fan | xiaomi.fan.p76 | Proprietary chip _MHCWB5G-B_ | [link](../../pull/116) | [link](https://home.miot-spec.com/spec/xiaomi.fan.p76)
 Xiaomi Smart Pet Food Feeder 2 | xiaomi.feeder.iv2001 | Proprietary chip _MHCW05P-B_ | [link](../../pull/72) | [link](https://home.miot-spec.com/spec/xiaomi.feeder.iv2001)
 Xiaomi Smart Graphene Heater | xiaomi.heater.ma8 | No dedicated MCU | [link](../../issues/98) | [link](https://home.miot-spec.com/spec/xiaomi.heater.ma8)
 Xiaomi Smart Evaporative Humidifier | xiaomi.humidifier.3lite | Proprietary chip _MHCWB5G-B_ | [link](../../pull/105) | [link](https://home.miot-spec.com/spec/xiaomi.humidifier.3lite)


### PR DESCRIPTION
The "Xiaomi Smart Standing Air Circulation Fan" `xiaomi.fan.p76` uses the proprietary `MHCWB5G-B` module, so is incompatible from the factory.

However, it does have a separate GD32 MCU, and the WiFi module sits on a mezzanine PCB that has an edge connector with only `5V`, `GND`, `RX`, `TX`, and `RST`, so it should be trivially simple to desolder the entire mezzanine and wire up any ESP32 module to achieve compatibility.

<img width="3000" height="4000" alt="20260708_172052" src="https://github.com/user-attachments/assets/49a30c7f-5b5c-4aee-98e2-51c44df873c4" />
