### PR TITLE
fix: add braces around logging statements to fix -Wempty-body

### DIFF
--- a/components/miot/fan/miot_fan.cpp
+++ b/components/miot/fan/miot_fan.cpp
@@ -29,8 +29,9 @@ void MiotFan::setup() {
 
   this->parent_->register_listener(this->speed_siid_, this->speed_piid_, true, mvtUInt, [this](const MiotValue &value) {
     if (!this->state) {
-      if (value.as_uint != 0)
+      if (value.as_uint != 0) {
         ESP_LOGW(TAG, "Ignoring MCU reported speed, fan is off");
+      }
       return;
     }
     if (this->has_preset_mode()) {
@@ -98,10 +99,12 @@ void MiotFan::dump_config() {
     ESP_LOGCONFIG(TAG, "  Preset Modes SIID: %" PRIu32, this->preset_modes_siid_);
     ESP_LOGCONFIG(TAG, "  Preset Modes PIID: %" PRIu32, this->preset_modes_piid_);
     ESP_LOGCONFIG(TAG, "  Preset Modes:");
-    for (auto const &it : this->preset_modes_)
+    for (auto const &it : this->preset_modes_) {
       ESP_LOGCONFIG(TAG, "    %u: %s", it.first, it.second);
-    if (this->manual_speed_preset_.has_value())
+    }
+    if (this->manual_speed_preset_.has_value()) {
       ESP_LOGCONFIG(TAG, "  Manual Preset Mode: %" PRIu8, *this->manual_speed_preset_);
+    }
   }
 }
 

--- a/components/miot/miot.cpp
+++ b/components/miot/miot.cpp
@@ -137,10 +137,12 @@ void Miot::loop() {
 
 void Miot::dump_config() {
   ESP_LOGCONFIG(TAG, "MIoT:");
-  if (!model_.empty())
+  if (!model_.empty()) {
     ESP_LOGCONFIG(TAG, "  Model: %s", model_.c_str());
-  if (!mcu_version_.empty())
+  }
+  if (!mcu_version_.empty()) {
     ESP_LOGCONFIG(TAG, "  MCU Version: %s", mcu_version_.c_str());
+  }
   ESP_LOGCONFIG(TAG, "  Heartbeat SIID: %" PRIu32, this->heartbeat_siid_);
   ESP_LOGCONFIG(TAG, "  Heartbeat PIID: %" PRIu32, this->heartbeat_piid_);
   ESP_LOGCONFIG(TAG, "  OTA net indicator: %s", this->ota_net_indicator_.c_str());
@@ -151,8 +153,9 @@ void Miot::dump_config() {
 #endif
   if (!mcu_log_.empty()) {
     ESP_LOGCONFIG(TAG, "  MCU Log:");
-    for (auto it = mcu_log_.cbegin(); it != mcu_log_.cend(); ++it)
+    for (auto it = mcu_log_.cbegin(); it != mcu_log_.cend(); ++it) {
       ESP_LOGCONFIG(TAG, "    %s", (*it).c_str());
+    }
   }
 }
 
@@ -435,13 +438,15 @@ void Miot::process_message_() {
     send_reply_(get_mac_address().c_str());
   } else if (cmd == "model") {
     model_ = strtok_r(nullptr, " ", &saveptr);
-    if (!model_.empty())
+    if (!model_.empty()) {
       ESP_LOGI(TAG, "Model: %s", model_.c_str());
+    }
     send_reply_("ok");
   } else if (cmd == "mcu_version") {
     mcu_version_ = strtok_r(nullptr, " ", &saveptr);
-    if (!mcu_version_.empty())
+    if (!mcu_version_.empty()) {
       ESP_LOGI(TAG, "MCU Version: %s", mcu_version_.c_str());
+    }
     send_reply_("ok");
   } else if (cmd == "error") {
     const char *error = strtok_r(nullptr, "\"", &saveptr);

--- a/components/miot/select/miot_select.cpp
+++ b/components/miot/select/miot_select.cpp
@@ -41,8 +41,9 @@ void MiotSelect::dump_config() {
   ESP_LOGCONFIG(TAG, "  PIID: %" PRIu32, this->piid_);
   ESP_LOGCONFIG(TAG, "  Options are:");
   const auto &options = this->traits.get_options();
-  for (auto i = 0; i < this->mappings_.size(); i++)
+  for (auto i = 0; i < this->mappings_.size(); i++) {
     ESP_LOGCONFIG(TAG, "    %i: %s", this->mappings_.at(i), options.at(i));
+  }
 }
 
 }  // namespace miot


### PR DESCRIPTION
## Fix -Wempty-body warnings

`ESP_LOG*` macros expand to nothing below their log level, so an unbraced
`if (cond) ESP_LOGCONFIG(...);`
compiles to
`if (cond);`
and triggers `-Wempty-body` on ESP-IDF builds.
